### PR TITLE
Fix capture_viewport moving the user's view (marked ReadOnly)

### DIFF
--- a/plugin/Functions/CaptureViewport.cs
+++ b/plugin/Functions/CaptureViewport.cs
@@ -5,6 +5,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using Newtonsoft.Json.Linq;
 using Rhino;
+using Rhino.DocObjects;
 using Rhino.Display;
 
 namespace RhinoMCPPlugin.Functions;
@@ -48,47 +49,87 @@ public partial class RhinoMCPFunctions
         width = Math.Max(width, 100);
         height = Math.Max(height, 100);
 
-        // Find the target view
+        // capture_viewport is ReadOnly, so it must leave every viewport exactly as it
+        // found it. Resolving a projection target (top/front/...) reprojects AND renames
+        // the active view, and zoom_to_fit moves the camera, so snapshot the projection
+        // and name of the views we might touch and restore them in the finally below.
+        RhinoView activeView = doc.Views.ActiveView;
+        ViewportInfo savedActiveState = activeView != null
+            ? new ViewportInfo(activeView.ActiveViewport)
+            : null;
+        string savedActiveName = activeView?.ActiveViewport.Name;
+
+        // Find the target view (may temporarily reproject the active view)
         RhinoView targetView = GetTargetView(doc, viewportTarget);
         if (targetView == null)
         {
             throw new InvalidOperationException($"Viewport '{viewportTarget}' not found. Available viewports: Perspective, Top, Front, Right, Back, Left, Bottom, or use 'active' for the current view.");
         }
 
-        // Store viewport name
-        string viewportName = targetView.ActiveViewport.Name ?? viewportTarget;
+        // A named projection view (e.g. an existing "Top") is a different view than the
+        // active one; snapshot it too since zoom_to_fit would otherwise leave it zoomed.
+        bool targetIsActive = activeView != null
+            && targetView.ActiveViewportID == activeView.ActiveViewportID;
+        ViewportInfo savedTargetState = !targetIsActive
+            ? new ViewportInfo(targetView.ActiveViewport)
+            : null;
+        string savedTargetName = !targetIsActive ? targetView.ActiveViewport.Name : null;
 
-        // Apply zoom to fit if requested
-        if (zoomToFit && doc.Objects.Count > 0)
+        try
         {
-            targetView.ActiveViewport.ZoomExtents();
+            // Store viewport name
+            string viewportName = targetView.ActiveViewport.Name ?? viewportTarget;
+
+            // Apply zoom to fit if requested
+            if (zoomToFit && doc.Objects.Count > 0)
+            {
+                targetView.ActiveViewport.ZoomExtents();
+                doc.Views.Redraw();
+            }
+
+            string base64Data = CaptureViewToPngBase64(
+                targetView,
+                width,
+                height,
+                showGrid,
+                showAxes,
+                showCplaneAxes,
+                "capture_viewport");
+
+            RhinoApp.WriteLine($"Captured viewport '{viewportName}' ({width}x{height})");
+
+            return new JObject
+            {
+                ["image_data"] = base64Data,
+                ["mime_type"] = "image/png",
+                ["width"] = width,
+                ["height"] = height,
+                ["viewport_name"] = viewportName,
+                ["viewport_target"] = viewportTarget,
+                ["show_grid"] = showGrid,
+                ["show_axes"] = showAxes,
+                ["show_cplane_axes"] = showCplaneAxes,
+                ["object_count"] = doc.Objects.Count
+            };
+        }
+        finally
+        {
+            // Restore any viewport we may have changed (projection and name) so the
+            // capture leaves no visible side effect on the user's views.
+            if (savedActiveState != null)
+            {
+                activeView.ActiveViewport.SetViewProjection(savedActiveState, true);
+                if (savedActiveName != null && activeView.ActiveViewport.Name != savedActiveName)
+                    activeView.ActiveViewport.Name = savedActiveName;
+            }
+            if (savedTargetState != null)
+            {
+                targetView.ActiveViewport.SetViewProjection(savedTargetState, true);
+                if (savedTargetName != null && targetView.ActiveViewport.Name != savedTargetName)
+                    targetView.ActiveViewport.Name = savedTargetName;
+            }
             doc.Views.Redraw();
         }
-
-        string base64Data = CaptureViewToPngBase64(
-            targetView,
-            width,
-            height,
-            showGrid,
-            showAxes,
-            showCplaneAxes,
-            "capture_viewport");
-
-        RhinoApp.WriteLine($"Captured viewport '{viewportName}' ({width}x{height})");
-
-        return new JObject
-        {
-            ["image_data"] = base64Data,
-            ["mime_type"] = "image/png",
-            ["width"] = width,
-            ["height"] = height,
-            ["viewport_name"] = viewportName,
-            ["viewport_target"] = viewportTarget,
-            ["show_grid"] = showGrid,
-            ["show_axes"] = showAxes,
-            ["show_cplane_axes"] = showCplaneAxes,
-            ["object_count"] = doc.Objects.Count
-        };
     }
 
     [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility",
@@ -178,27 +219,26 @@ public partial class RhinoMCPFunctions
     }
 
     /// <summary>
-    /// Finds a view by projection type, or temporarily sets the active view to that projection.
+    /// Finds a view by projection type, or temporarily reprojects the active view.
+    /// The caller (CaptureViewport) is responsible for restoring viewport state.
     /// </summary>
     private RhinoView FindViewByProjection(RhinoDoc doc, DefinedViewportProjection projection)
     {
         string projectionName = projection.ToString();
 
-        // First, try to find existing view with matching name
+        // First, try to find an existing view whose title matches the projection
         foreach (var view in doc.Views)
         {
             if (view.ActiveViewport.Name?.Equals(projectionName, StringComparison.OrdinalIgnoreCase) == true)
                 return view;
         }
 
-        // If not found by name, use the active view and temporarily set the projection
+        // No dedicated view exists: temporarily reproject the active view (this also
+        // renames it). CaptureViewport snapshots and restores both projection and name,
+        // so the change is invisible to the user.
         var activeView = doc.Views.ActiveView;
         if (activeView != null)
         {
-            // Store original state
-            var originalProjection = activeView.ActiveViewport.IsParallelProjection;
-
-            // Set the desired projection
             activeView.ActiveViewport.SetProjection(projection, projectionName, false);
             doc.Views.Redraw();
 

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -707,6 +707,48 @@ public partial class RhinoMCPFunctions
             results["split_curve"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
         }
 
+        // Test 24: CaptureViewport must not move the user's camera (ReadOnly contract)
+        try
+        {
+            var activeViewport = doc.Views.ActiveView?.ActiveViewport;
+            if (activeViewport == null)
+                throw new Exception("No active viewport to test against");
+
+            // zoom_to_fit moves the camera; a correct ReadOnly handler restores it.
+            string nameBefore = activeViewport.Name;
+            var before = new Rhino.DocObjects.ViewportInfo(activeViewport);
+            before.GetFrustum(out double bl, out double br, out double bb, out double bt, out _, out _);
+
+            CaptureViewport(new JObject
+            {
+                ["viewport"] = "active",
+                ["zoom_to_fit"] = true,
+                ["width"] = 200,
+                ["height"] = 200
+            });
+
+            var after = new Rhino.DocObjects.ViewportInfo(activeViewport);
+            after.GetFrustum(out double al, out double ar, out double ab, out double at, out _, out _);
+
+            double cameraDrift = before.CameraLocation.DistanceTo(after.CameraLocation);
+            double frustumDrift = Math.Abs(bl - al) + Math.Abs(br - ar) + Math.Abs(bb - ab) + Math.Abs(bt - at);
+            bool nameKept = activeViewport.Name == nameBefore;
+            if (cameraDrift > 1e-6 || frustumDrift > 1e-6 || !nameKept)
+                throw new Exception($"capture_viewport changed the active view (cameraDrift={cameraDrift:G4}, frustumDrift={frustumDrift:G4}, nameKept={nameKept})");
+
+            results["capture_viewport_readonly"] = new JObject
+            {
+                ["status"] = "pass",
+                ["camera_drift"] = cameraDrift,
+                ["frustum_drift"] = frustumDrift
+            };
+            VisualUpdate("capture_viewport left the camera unchanged");
+        }
+        catch (Exception e)
+        {
+            results["capture_viewport_readonly"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
         // Cleanup
         if (!visualMode)
         {


### PR DESCRIPTION
I've been leaning on rhinomcp pretty heavily for a project where I emboss fingerprints onto parts. It started out embossing them straight onto the .3dm, and these days I run most of it through STL, but either way I'm calling capture_viewport constantly to check how the emboss looks before I move on. That's how I noticed this one: my Perspective view kept getting renamed and ending up pointed somewhere I hadn't left it.

capture_viewport is marked `ReadOnly = true`, but it isn't read-only in practice.

- If you ask for a projection that doesn't have its own view (say "bottom" on the default Top/Front/Right/Perspective layout), `GetTargetView` reprojects your active view to take the shot. `SetProjection` also renames the viewport, and nothing puts the projection or the name back afterwards. `FindViewByProjection` even reads the original projection into a local and then never uses it, so it looks like a restore was meant to be there and got dropped.
- `zoom_to_fit` runs `ZoomExtents` on the target view and never restores the camera.

So you can end up looking at a different view, with a different name, than before you called it. In my case the Perspective viewport quietly turned into "Bottom" partway through a session, and it took me a while to figure out where that was coming from.

The fix saves each viewport I might touch before the capture (its projection through `ViewportInfo`, plus its name) and restores them in a `finally`, so the camera, zoom, projection and name all land back where they started. The active view is always saved, since that's the one a projection target reprojects, and a separate named target view is saved too, since `zoom_to_fit` would otherwise leave that one zoomed. The dead `originalProjection` local is gone as well.

Nothing changes for callers. Same command, same params, same response. The only difference is that your views stop moving.

Testing:
- `dotnet build plugin/rhinomcp.sln -c Release`, clean
- `pytest` in `server/`, 138 passing
- `python contracts/test_schemas.py`, all passing
- Added an `MCPTestCommand` case (`capture_viewport_readonly`) that snapshots the active viewport, runs a capture with `zoom_to_fit`, and fails if the camera or name moved
- Ran it against Rhino 8 with this build loaded, driving capture_viewport through both paths (zoom on the active view, and a reproject to a view that doesn't exist). Camera, frustum, projection and name all came back unchanged, and the PNG was valid

To see it yourself:
1. Open Rhino and run `mcpstart`
2. Make Perspective active and orbit to something you'll recognize
3. Call capture_viewport with `{"viewport": "bottom", "zoom_to_fit": true}`
4. You get the bottom shot back, and Perspective is right where you left it with its name intact. Before this change it flips to Bottom and stays there.

If you'd rather restore the viewport a different way, I'm happy to change it.
