### PR TITLE
Replace the deprecated jsonschema RefResolver with referencing

### DIFF
--- a/server/src/rhinomcp/validation.py
+++ b/server/src/rhinomcp/validation.py
@@ -12,10 +12,14 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger("RhinoMCPValidation")
 
-# Try to import jsonschema, but make it optional
+# Try to import jsonschema, but make it optional.
+# referencing is a hard dependency of jsonschema>=4.18 (we require >=4.20),
+# so grouping the imports keeps the "jsonschema is optional" behavior intact.
 try:
     import jsonschema
-    from jsonschema import Draft202012Validator, RefResolver
+    from jsonschema import Draft202012Validator
+    from referencing import Registry, Resource
+    from referencing.jsonschema import DRAFT202012
     HAS_JSONSCHEMA = True
 except ImportError:
     HAS_JSONSCHEMA = False
@@ -64,51 +68,44 @@ def _load_schema(schema_path: str) -> Dict[str, Any]:
     return schema
 
 
-def _get_resolver(schema: Optional[Dict[str, Any]] = None, schema_rel_path: Optional[str] = None) -> Optional["RefResolver"]:
-    """Create a resolver for $ref resolution.
+# Cache for the shared $ref registry
+_registry: Optional["Registry"] = None
 
-    The base URI is set to the directory holding the schema being validated
-    (e.g. contracts/commands/ for command schemas), so:
-      - the schema's bare `$id` (e.g. "create_object.json") resolves to the
-        actual file location, and local `#/$defs/...` refs work,
-      - relative cross-directory refs like `../common/definitions.json` resolve
-        against the same directory hierarchy on disk.
 
-    The schema and the common definitions are pre-registered in the store so
-    no filesystem lookup is required at validation time.
+def _get_registry() -> Optional["Registry"]:
+    """Build (once) the referencing.Registry for cross-file $ref resolution.
+
+    Refs resolve in the schemas' own relative-URI space (bare `$id`s like
+    "create_object.json"), no file:// URIs involved. Every contract schema is
+    registered under its filename so cross-file refs resolve from memory:
+      - same-directory refs like "object_info.json"
+        (used by responses/get_objects_result.json),
+      - "common/definitions.json", the form a "../common/definitions.json"
+        ref collapses to when resolved against a bare `$id`,
+      - "../common/definitions.json" verbatim, for a schema without `$id`.
+    The schema being validated needs no registration of its own: the
+    validator anchors it as the resolver root, which covers its `$id` and
+    local `#/$defs/...` refs.
     """
+    global _registry
     if not HAS_JSONSCHEMA:
         return None
 
-    contracts_dir = _get_contracts_dir()
-
-    # Pick a base_uri co-located with the schema so its $id and relative refs
-    # both resolve consistently.
-    if schema_rel_path is not None:
-        rel_dir = Path(schema_rel_path).parent.as_posix()
-        if rel_dir and rel_dir != ".":
-            base_uri = f"file://{contracts_dir}/{rel_dir}/"
-        else:
-            base_uri = f"file://{contracts_dir}/"
-    else:
-        base_uri = f"file://{contracts_dir}/"
-
-    # Pre-register common definitions under the URI relative refs will produce.
-    common_schema = _load_schema("common/definitions.json")
-    common_uri_from_base = f"{base_uri}../common/definitions.json" if schema_rel_path else f"{base_uri}common/definitions.json"
-
-    store: Dict[str, Any] = {
-        f"file://{contracts_dir}/common/definitions.json": common_schema,
-        common_uri_from_base: common_schema,
-    }
-    if schema is not None and schema_rel_path is not None:
-        schema_filename = Path(schema_rel_path).name
-        store[f"{base_uri}{schema_filename}"] = schema
-        schema_id = schema.get("$id")
-        if isinstance(schema_id, str) and schema_id:
-            store[f"{base_uri}{schema_id}"] = schema
-
-    return RefResolver(base_uri, {}, store=store)
+    if _registry is None:
+        contracts_dir = _get_contracts_dir()
+        resources = []
+        for rel_dir in ("commands", "responses", "common"):
+            for path in sorted((contracts_dir / rel_dir).glob("*.json")):
+                resource = Resource.from_contents(
+                    _load_schema(f"{rel_dir}/{path.name}"),
+                    default_specification=DRAFT202012,
+                )
+                resources.append((path.name, resource))
+                if rel_dir == "common":
+                    resources.append((f"common/{path.name}", resource))
+                    resources.append((f"../common/{path.name}", resource))
+        _registry = Registry().with_resources(resources)
+    return _registry
 
 
 def validate_command(command_type: str, params: Dict[str, Any], raise_on_error: bool = True) -> bool:
@@ -135,9 +132,8 @@ def validate_command(command_type: str, params: Dict[str, Any], raise_on_error: 
 
     try:
         schema = _load_schema(schema_path)
-        resolver = _get_resolver(schema=schema, schema_rel_path=schema_path)
 
-        validator = Draft202012Validator(schema, resolver=resolver)
+        validator = Draft202012Validator(schema, registry=_get_registry())
         validator.validate(params)
 
         logger.debug(f"Validation passed for {command_type}")
@@ -197,9 +193,8 @@ def validate_response(command_type: str, response: Dict[str, Any], raise_on_erro
 
     try:
         schema = _load_schema(schema_path)
-        resolver = _get_resolver(schema=schema, schema_rel_path=schema_path)
 
-        validator = Draft202012Validator(schema, resolver=resolver)
+        validator = Draft202012Validator(schema, registry=_get_registry())
         validator.validate(response)
 
         logger.debug(f"Response validation passed for {command_type}")

--- a/server/tests/test_validation.py
+++ b/server/tests/test_validation.py
@@ -1,0 +1,141 @@
+"""Tests for rhinomcp.validation $ref resolution.
+
+The contract schemas carry bare relative $ids (e.g. "create_object.json") and
+reference shared types as "../common/definitions.json#/$defs/...". These tests
+pin that both ref styles keep resolving — and keep being enforced — through
+the public validate_command / validate_response entry points.
+"""
+
+import sys
+import warnings
+
+import jsonschema
+import pytest
+
+from rhinomcp.validation import validate_command, validate_response
+
+GUID = "12345678-1234-1234-1234-123456789012"
+
+
+class TestCrossFileRefResolution:
+    """$refs into common/definitions.json must resolve and be enforced."""
+
+    def test_command_refs_resolve(self):
+        # modify_object's id and new_color fields are $refs into
+        # ../common/definitions.json (guid, color).
+        assert validate_command(
+            "modify_object", {"id": GUID, "new_color": [0, 255, 0]}
+        )
+
+    def test_command_refs_enforced(self):
+        # A bad guid violates the referenced common definition. If refs were
+        # silently skipped instead of resolved, this would pass validation.
+        with pytest.raises(jsonschema.ValidationError):
+            validate_command("modify_object", {"id": "not-a-guid"})
+
+    def test_response_refs_resolve(self):
+        assert validate_response(
+            "get_object_info",
+            {
+                "id": GUID,
+                "name": "MyBox",
+                "type": "BOX",
+                "layer": "Default",
+                "material": "-1",
+                "color": {"r": 255, "g": 0, "b": 0},
+                "bounding_box": [[-1, -1, -1], [1, 1, 1]],
+                "geometry": {},
+            },
+        )
+
+    def test_response_refs_enforced(self):
+        # bounding_box is a $ref chain into common definitions
+        # (boundingBox -> point3d); 2D corners must be rejected.
+        with pytest.raises(jsonschema.ValidationError):
+            validate_response(
+                "get_object_info",
+                {
+                    "id": GUID,
+                    "name": "MyBox",
+                    "type": "BOX",
+                    "layer": "Default",
+                    "material": "-1",
+                    "color": {"r": 255, "g": 0, "b": 0},
+                    "bounding_box": [[-1, -1], [1, 1]],
+                    "geometry": {},
+                },
+            )
+
+    def test_local_defs_refs_resolve(self):
+        # create_object discriminates params by type via local #/$defs refs;
+        # sphere params on a BOX must be rejected through that ref chain.
+        assert validate_command(
+            "create_object",
+            {"type": "BOX", "params": {"width": 1, "length": 2, "height": 3}},
+        )
+        with pytest.raises(jsonschema.ValidationError):
+            validate_command(
+                "create_object", {"type": "BOX", "params": {"radius": 1}}
+            )
+
+    def test_same_directory_response_refs_resolve(self):
+        # responses/get_objects_result.json refs object_info.json by bare
+        # name (a same-directory cross-file ref). Under the old RefResolver
+        # this never resolved (its file:// fallback fails on Windows), so
+        # validating a real get_objects page always raised.
+        assert validate_response(
+            "get_objects",
+            {
+                "objects": [
+                    {
+                        "id": GUID,
+                        "name": "Box1",
+                        "type": "BOX",
+                        "layer": "Default",
+                        "color": {"r": 1, "g": 2, "b": 3},
+                        "bounding_box": [[0, 0, 0], [1, 1, 1]],
+                    }
+                ],
+                "total_matching": 1,
+                "offset": 0,
+                "limit": 50,
+                "has_more": False,
+            },
+        )
+
+    def test_same_directory_response_refs_enforced(self):
+        with pytest.raises(jsonschema.ValidationError):
+            validate_response(
+                "get_objects",
+                {
+                    "objects": [{"id": "not-a-guid"}],
+                    "total_matching": 1,
+                    "offset": 0,
+                    "limit": 50,
+                    "has_more": False,
+                },
+            )
+
+
+class TestNoRefResolverDeprecation:
+    """jsonschema.RefResolver is deprecated since 4.18 and slated for removal.
+    Importing or using the validation module must not touch it."""
+
+    def test_import_and_use_emit_no_refresolver_warning(self):
+        sys.modules.pop("rhinomcp.validation", None)
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                import rhinomcp.validation as validation
+
+                validation.validate_command(
+                    "modify_object", {"id": GUID, "new_color": [0, 255, 0]}
+                )
+            refresolver_warnings = [
+                w for w in caught if "RefResolver" in str(w.message)
+            ]
+            assert not refresolver_warnings
+        finally:
+            # Leave a cleanly imported module for later tests.
+            sys.modules.pop("rhinomcp.validation", None)
+            import rhinomcp.validation  # noqa: F401


### PR DESCRIPTION
Every import of `rhinomcp.validation` throws a DeprecationWarning on current jsonschema: `RefResolver` has been deprecated since 4.18 and they're going to remove it. What pushed me to fix it now is how it fails when that removal actually lands. The import sits inside the try/except ImportError that makes jsonschema optional, so validation wouldn't crash, it would just quietly flip `HAS_JSONSCHEMA` to false and stop validating anything. Schema checks silently turning themselves off is the kind of thing you find out about months later.

This moves the resolver to `referencing`, which is what jsonschema itself replaced RefResolver with. It's not a new dependency, jsonschema has required it since 4.18 and pyproject already pins >=4.20, so anywhere jsonschema imports, referencing imports too. The optional-jsonschema behavior doesn't change.

The new code is also simpler than what it replaces. The old resolver built file:// URIs from the contracts directory and pre-registered the schema being validated plus the common definitions in a store. Now there's one in-memory registry holding every contract schema under its bare filename, which is the URI space the schemas' own `$id`s and relative refs already live in. The schema being validated doesn't need registering at all, the validator anchors it as the resolver root. No filesystem lookups at validation time.

While checking I wasn't breaking anything, I swept every $ref in the contracts tree (127 refs across 74 files) through the resolver, and that turned up a bug that predates this change: `get_objects_result.json` refs `object_info.json` by bare name, same directory, and the old RefResolver never resolved it. Its file:// fallback builds a path that doesn't survive Windows (urlopen, WinError 3), so validating an actual get_objects page always raised. Nobody has hit it because `validate_response` currently has no callers. With every schema registered, the ref resolves and gets enforced: a page of valid object_info entries passes, a page with a bad guid gets rejected. Both pinned by tests.

I also ran the old and new modules side by side over 367 valid and invalid payloads to make sure the outcomes match. Zero mismatches. The only behavioral difference is the get_objects case above, where the old code raised a resolution error and the new one validates properly. And with jsonschema and referencing made unimportable, `HAS_JSONSCHEMA` still flips false and everything no-ops like before.

Testing:
- `pytest` in `server/`, 146 passing (138 existing, 8 new in tests/test_validation.py)
- `python contracts/test_schemas.py`, all passing
- the new tests pin: cross-file refs into the common definitions resolve and reject bad payloads through both `validate_command` and `validate_response`, local `#/$defs` dispatch in create_object still works, the same-directory response ref resolves and is enforced, and importing or using the module emits no RefResolver warning (that one fails on main and passes here)

Server-side Python only, nothing touches the wire or the plugin.