### PR TITLE
Wire validate_response into the response path

### DIFF
--- a/server/src/rhinomcp/server.py
+++ b/server/src/rhinomcp/server.py
@@ -300,7 +300,47 @@ class RhinoConnection:
                 logger.error(f"Rhino error: {response.get('message')}")
                 raise Exception(response.get("message", "Unknown error from Rhino"))
 
-            return response.get("result", {})
+            result = response.get("result", {})
+
+            # Post-flight: validate the unwrapped result against the response
+            # contract, mirroring the pre-flight semantics. The C# side doesn't
+            # validate anything against contracts/, so this is the only place
+            # plugin/contract drift gets caught. Note the command has already
+            # executed in Rhino by now: 'warn' logs and returns the result
+            # anyway; 'strict' raises. validate_response no-ops if jsonschema
+            # is missing or the command has no response schema.
+            if RHINO_VALIDATE != "off":
+                from rhinomcp.validation import HAS_JSONSCHEMA, validate_response
+
+                try:
+                    validate_response(command_type, result, raise_on_error=True)
+                except Exception as ve:
+                    # Only a genuine validation verdict gets the warn/strict
+                    # treatment. Anything else (unresolvable $ref, unreadable
+                    # schema file) is a schema-infrastructure problem, not
+                    # evidence the response is wrong — a successful command
+                    # must not fail because the local schema tooling broke.
+                    is_verdict = False
+                    if HAS_JSONSCHEMA:
+                        import jsonschema
+
+                        is_verdict = isinstance(ve, jsonschema.ValidationError)
+                    if not is_verdict:
+                        logger.warning(
+                            f"Could not validate response for {command_type} "
+                            f"(schema error): {ve}"
+                        )
+                    elif RHINO_VALIDATE == "strict":
+                        raise ValueError(
+                            f"Rhino executed '{command_type}' but the response "
+                            f"failed contract validation: {ve}"
+                        ) from ve
+                    else:
+                        logger.warning(
+                            f"Response validation failed for {command_type}: {ve}"
+                        )
+
+            return result
         except socket.timeout:
             logger.error("Socket timeout while waiting for response from Rhino")
             # Don't try to reconnect here - let the get_rhino_connection handle reconnection
@@ -334,7 +374,8 @@ class RhinoConnection:
                 logger.error(f"Raw response (first 200 bytes): {response_data[:200]}")
             raise Exception(f"Invalid response from Rhino: {str(e)}")
         except ValueError:
-            # Pre-flight validation failures — local, not a transport issue. Propagate.
+            # Pre/post-flight validation failures — local, not a transport
+            # issue. Propagate.
             raise
         except Exception as e:
             logger.error(f"Error communicating with Rhino: {str(e)}")

--- a/server/src/rhinomcp/validation.py
+++ b/server/src/rhinomcp/validation.py
@@ -176,7 +176,9 @@ def validate_response(command_type: str, response: Dict[str, Any], raise_on_erro
         "get_object_attributes": "object_attributes.json",
         "update_object_attributes": "object_attributes.json",
         "analyze_objects": "analyze_objects_result.json",
-        "get_selected_objects_info": "object_info.json",  # Returns array
+        # get_selected_objects_info is deliberately unmapped: it returns
+        # {"selected_objects": [...]}, which no current response schema
+        # describes (object_info.json would reject it on every call).
         "get_document_summary": "document_summary.json",
         "get_objects": "get_objects_result.json",
         "delete_object": "delete_result.json",

--- a/server/tests/mock_rhino_server.py
+++ b/server/tests/mock_rhino_server.py
@@ -34,8 +34,15 @@ class MockRhinoServer:
 
         # Mock document state
         self.objects: Dict[str, Dict[str, Any]] = {}
+        # Shaped like the plugin's SerializeLayer output (layer_info.json):
+        # color is an {r,g,b} object, parent is a guid.
         self.layers: Dict[str, Dict[str, Any]] = {
-            "Default": {"id": str(uuid.uuid4()), "name": "Default", "color": [0, 0, 0]}
+            "Default": {
+                "id": str(uuid.uuid4()),
+                "name": "Default",
+                "color": {"r": 0, "g": 0, "b": 0},
+                "parent": "00000000-0000-0000-0000-000000000000",
+            }
         }
         self.current_layer = "Default"
         self.undo_stack: list = []
@@ -760,6 +767,7 @@ class MockRhinoServer:
         )
         return {
             "image_data": png_b64,
+            "mime_type": "image/png",
             "viewport_name": params.get("viewport", "active"),
             "width": params.get("width", 800),
             "height": params.get("height", 600),

--- a/server/tests/test_connection.py
+++ b/server/tests/test_connection.py
@@ -232,6 +232,159 @@ class TestRuntimeValidation:
         importlib.import_module("rhinomcp.server")
 
 
+class TestResponseValidation:
+    """Post-flight schema validation of Rhino responses, behind the same
+    RHINO_MCP_VALIDATE switch as the pre-flight check."""
+
+    # A create_object result that satisfies responses/object_info.json.
+    VALID_OBJECT_INFO = {
+        "id": "12345678-1234-1234-1234-123456789012",
+        "name": "MyBox",
+        "type": "BOX",
+        "layer": "Default",
+        "material": "-1",
+        "color": {"r": 255, "g": 0, "b": 0},
+        "bounding_box": [[-1, -1, -1], [1, 1, 1]],
+        "geometry": {},
+    }
+
+    # Valid params so the pre-flight check passes and the response check is
+    # the only thing under test.
+    VALID_BOX_PARAMS = {
+        "type": "BOX",
+        "params": {"width": 1.0, "length": 1.0, "height": 1.0},
+    }
+
+    def _connect_with_response(self, mock_socket_class, result):
+        """Connection whose next receive yields the given result payload.
+
+        Stubs receive_full_response rather than raw socket bytes: these tests
+        pin validation policy, not wire framing, so they stay valid if the
+        wire format changes (framing has its own coverage).
+        """
+        from rhinomcp.server import RhinoConnection
+
+        mock_sock = MagicMock()
+        mock_socket_class.return_value = mock_sock
+
+        conn = RhinoConnection(host="127.0.0.1", port=1999)
+        conn.connect()
+        payload = json.dumps({"status": "success", "result": result}).encode(
+            "utf-8"
+        )
+        conn.receive_full_response = lambda sock, buffer_size=8192: payload
+        return conn
+
+    @patch("socket.socket")
+    def test_strict_mode_rejects_contract_violating_response(
+        self, mock_socket_class
+    ):
+        import rhinomcp.server as srv
+
+        # An empty result is missing every required object_info field.
+        conn = self._connect_with_response(mock_socket_class, {})
+
+        original_mode = srv.RHINO_VALIDATE
+        srv.RHINO_VALIDATE = "strict"
+        try:
+            with pytest.raises(ValueError, match="failed contract validation"):
+                conn.send_command("create_object", self.VALID_BOX_PARAMS)
+        finally:
+            srv.RHINO_VALIDATE = original_mode
+
+    @patch("socket.socket")
+    def test_strict_mode_passes_valid_response_through(self, mock_socket_class):
+        import rhinomcp.server as srv
+
+        conn = self._connect_with_response(
+            mock_socket_class, self.VALID_OBJECT_INFO
+        )
+
+        original_mode = srv.RHINO_VALIDATE
+        srv.RHINO_VALIDATE = "strict"
+        try:
+            result = conn.send_command("create_object", self.VALID_BOX_PARAMS)
+        finally:
+            srv.RHINO_VALIDATE = original_mode
+
+        assert result == self.VALID_OBJECT_INFO
+
+    @patch("socket.socket")
+    def test_warn_mode_logs_and_returns_result_anyway(
+        self, mock_socket_class, caplog
+    ):
+        """The default 'warn' mode must never turn a successful Rhino command
+        into a client error — the command already executed."""
+        import rhinomcp.server as srv
+
+        conn = self._connect_with_response(mock_socket_class, {})
+
+        original_mode = srv.RHINO_VALIDATE
+        srv.RHINO_VALIDATE = "warn"
+        try:
+            with caplog.at_level("WARNING", logger="RhinoMCPServer"):
+                result = conn.send_command("create_object", self.VALID_BOX_PARAMS)
+        finally:
+            srv.RHINO_VALIDATE = original_mode
+
+        assert result == {}
+        assert any(
+            "Response validation failed for create_object" in r.message
+            for r in caplog.records
+        )
+
+    @patch("socket.socket")
+    def test_unmapped_command_skips_response_validation(self, mock_socket_class):
+        """get_selected_objects_info returns {"selected_objects": [...]}, which
+        no response schema describes — it must pass untouched even in strict."""
+        import rhinomcp.server as srv
+
+        result_payload = {"selected_objects": [{"id": "1", "name": "Box1"}]}
+        conn = self._connect_with_response(mock_socket_class, result_payload)
+
+        original_mode = srv.RHINO_VALIDATE
+        srv.RHINO_VALIDATE = "strict"
+        try:
+            result = conn.send_command("get_selected_objects_info", {})
+        finally:
+            srv.RHINO_VALIDATE = original_mode
+
+        assert result == result_payload
+
+    @patch("socket.socket")
+    def test_schema_infrastructure_error_never_fails_the_command(
+        self, mock_socket_class, caplog
+    ):
+        """A broken schema (unresolvable $ref, unreadable file) is not a
+        verdict on the response. Even in strict mode the result must come
+        back, with a 'could not validate' warning instead of a failure."""
+        import rhinomcp.server as srv
+
+        conn = self._connect_with_response(
+            mock_socket_class, self.VALID_OBJECT_INFO
+        )
+
+        original_mode = srv.RHINO_VALIDATE
+        srv.RHINO_VALIDATE = "strict"
+        try:
+            with patch(
+                "rhinomcp.validation.validate_response",
+                side_effect=RuntimeError("Unresolvable: object_info.json"),
+            ):
+                with caplog.at_level("WARNING", logger="RhinoMCPServer"):
+                    result = conn.send_command(
+                        "create_object", self.VALID_BOX_PARAMS
+                    )
+        finally:
+            srv.RHINO_VALIDATE = original_mode
+
+        assert result == self.VALID_OBJECT_INFO
+        assert any(
+            "Could not validate response for create_object" in r.message
+            for r in caplog.records
+        )
+
+
 class TestSendCommand:
     """Tests for the send_command method."""
 


### PR DESCRIPTION
I was in validation.py for the RefResolver migration (#29) and noticed `validate_response` has no callers. It's fully implemented, contracts/README.md documents it as the way to validate received responses, and nothing ever calls it. Commands get checked before they go out, but responses come back from the plugin completely unchecked, and the C# side doesn't validate against the contracts either. So half the contract surface was enforced and the other half just looked like it was.

This wires `validate_response` into `_send_command_once` right after the result is unwrapped, behind the same `RHINO_MCP_VALIDATE` switch with the same semantics: off skips, warn (the default) logs and returns the result anyway, strict raises. One thing I did differently from the pre-flight check: by the time a response fails validation the command has already run in Rhino, so the strict error message says exactly that instead of implying the command was blocked. And in warn mode a successful command can never turn into a client error, which is why warn stays the default.

Wiring it in turned up three spots where things had drifted. All fixed here.

The `response_schema_map` pointed get_selected_objects_info at object_info.json with a "Returns array" comment. The handler actually returns `{"selected_objects": [...]}`, the C# and the wrapper tests both agree on that, so the mapping would have failed on every single call. No current schema describes that shape, so I removed the entry with a comment saying why. If you'd rather have a proper selected_objects_result.json schema instead, happy to add one.

The other two were the mock Rhino server drifting from the real plugin. Its capture_viewport response was missing `mime_type`, which the schema requires and CaptureViewport.cs has always returned. And its seed Default layer carried the color as an `[r, g, b]` array with no parent, which fails layer_info.json even though the real plugin's SerializeLayer has always returned the right shape (I checked that against a live Rhino). Both fixes just bring the mock in line with the plugin.

One judgment call I want to be upfront about. Not every exception out of `validate_response` means the response is bad. An unresolvable $ref or an unreadable schema file means our own schema tooling broke, and a command that succeeded in Rhino shouldn't start failing because of that. So genuine ValidationErrors get the warn/strict treatment, and anything else logs a "could not validate" line and lets the result through in every mode. This isn't hypothetical either: get_objects_result.json refs object_info.json in a way the current resolver can't resolve on Windows (separate latent bug, fix in flight in #29), and without this guard every non-empty get_objects response would fail strict mode for reasons that have nothing to do with Rhino.

Testing:
- `pytest` in `server/`, 143 passing (138 existing, 5 new in test_connection.py: strict rejects a bad response, strict passes a valid one, warn logs and returns, unmapped commands skip, schema errors never fail the command)
- `python contracts/test_schemas.py`, all passing
- ran one call per mapped command through the real send path against the mock in strict mode, 15 for 15 clean
- same idea against a live Rhino 8 for the read-only commands (document summary, get_objects, current layer, rhinoscript exec, capture_viewport, plus the unmapped get_selected_objects_info), every real plugin response validates
- the integration suite under RHINO_MCP_VALIDATE=strict has one failure that's already there on main: a test sends deliberately bad params and expects the plugin's error message, but strict pre-flight rejects them before the send. Reproduces on unmodified main, unrelated to this change. The suite's default warn mode is green either way.

Python only, nothing changes on the wire or in the plugin.