### PR TITLE
Add length-prefixed framing to the TCP bridge

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -32,6 +32,11 @@ contracts/
 
 ## Protocol Format
 
+On the wire, every message in both directions is one frame: a 4-byte
+big-endian length header followed by that many bytes of UTF-8 JSON. The
+plugin also accepts legacy unframed connections (bare JSON, detected by the
+first byte) for older clients.
+
 ### Command (Python → C#)
 
 ```json

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -297,6 +297,20 @@ objects, and executes every command through `RhinoApp.InvokeOnUiThread(...)`.
 This is required because RhinoCommon and Grasshopper document APIs must run on
 Rhino's main thread.
 
+### Wire Framing
+
+Messages in both directions are length-prefixed: a 4-byte big-endian size
+header followed by that many bytes of UTF-8 JSON. This makes message
+boundaries exact, so pipelined commands and back-to-back responses cannot be
+misread, and frames split across TCP segments are read until complete.
+
+The plugin stays compatible with older unframed clients by sniffing the first
+byte of each connection: bare JSON (`{` or whitespace) selects the legacy
+unframed protocol for that connection, while a frame header's first byte is
+always below those values (frame sizes are capped at 64 MB). The bundled
+Python server always speaks the framed protocol and reports an actionable
+error if it detects an unframed (pre-framing) plugin.
+
 ### Handler Dispatch
 
 Dispatch is reflection based. `RhinoMCPFunctions.GetDispatchTable()` scans

--- a/plugin/RhinoMCPServer.cs
+++ b/plugin/RhinoMCPServer.cs
@@ -24,6 +24,22 @@ namespace RhinoMCPPlugin
 {
     public class RhinoMCPServer
     {
+        // Wire framing: a 4-byte big-endian length header followed by UTF-8
+        // JSON, in both directions. Legacy (pre-framing) clients send bare
+        // JSON instead; the first byte of a connection decides which protocol
+        // that connection speaks. The size cap bounds memory per frame and
+        // keeps the header's first byte below any byte a legacy client could
+        // open with ('{' or whitespace), so the sniff is unambiguous.
+        private const int FrameHeaderSize = 4;
+        private const int MaxFrameSize = 64 * 1024 * 1024;
+
+        private enum ClientProtocol
+        {
+            Undecided,
+            Framed,
+            Legacy
+        }
+
         private string host;
         private int port;
         private bool running;
@@ -165,7 +181,8 @@ namespace RhinoMCPPlugin
             RhinoApp.WriteLine("Client handler started");
 
             byte[] buffer = new byte[8192];
-            string incompleteData = string.Empty;
+            var pending = new List<byte>();
+            ClientProtocol protocol = ClientProtocol.Undecided;
 
             try
             {
@@ -185,57 +202,42 @@ namespace RhinoMCPPlugin
                                 break;
                             }
 
-                            string data = Encoding.UTF8.GetString(buffer, 0, bytesRead);
-                            incompleteData += data;
-
-                            try
+                            for (int i = 0; i < bytesRead; i++)
                             {
-                                // Try to parse as JSON
-                                JObject command = JObject.Parse(incompleteData);
-                                incompleteData = string.Empty;
-
-                                // Execute command on Rhino's main thread
-                                RhinoApp.InvokeOnUiThread(new Action(() =>
-                                {
-                                    try
-                                    {
-                                        JObject response = ExecuteCommand(command);
-                                        string responseJson = JsonConvert.SerializeObject(response);
-
-                                        try
-                                        {
-                                            byte[] responseBytes = Encoding.UTF8.GetBytes(responseJson);
-                                            stream.Write(responseBytes, 0, responseBytes.Length);
-                                        }
-                                        catch
-                                        {
-                                            RhinoApp.WriteLine("Failed to send response - client disconnected");
-                                        }
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        RhinoApp.WriteLine($"Error executing command: {e.Message}");
-                                        try
-                                        {
-                                            JObject errorResponse = new JObject
-                                            {
-                                                ["status"] = "error",
-                                                ["message"] = e.Message
-                                            };
-
-                                            byte[] errorBytes = Encoding.UTF8.GetBytes(errorResponse.ToString());
-                                            stream.Write(errorBytes, 0, errorBytes.Length);
-                                        }
-                                        catch
-                                        {
-                                            // Ignore send errors
-                                        }
-                                    }
-                                }));
+                                pending.Add(buffer[i]);
                             }
-                            catch (JsonException)
+
+                            if (protocol == ClientProtocol.Undecided)
                             {
-                                // Incomplete JSON data, wait for more
+                                protocol = SniffProtocol(pending[0]);
+                            }
+
+                            if (protocol == ClientProtocol.Framed)
+                            {
+                                // Drain every complete frame in the buffer so
+                                // pipelined commands all execute in order
+                                // instead of wedging the connection.
+                                while (TryExtractFrame(pending, out JObject framedCommand))
+                                {
+                                    DispatchCommand(framedCommand, stream, framed: true);
+                                }
+                            }
+                            else
+                            {
+                                // Legacy client: bare JSON, no framing. Keep
+                                // the original semantics: try to parse the
+                                // whole accumulation, wait for more on failure.
+                                string incompleteData = Encoding.UTF8.GetString(pending.ToArray());
+                                try
+                                {
+                                    JObject command = JObject.Parse(incompleteData);
+                                    pending.Clear();
+                                    DispatchCommand(command, stream, framed: false);
+                                }
+                                catch (JsonException)
+                                {
+                                    // Incomplete JSON data, wait for more
+                                }
                             }
                         }
                         else
@@ -267,6 +269,106 @@ namespace RhinoMCPPlugin
                 }
                 RhinoApp.WriteLine("Client handler stopped");
             }
+        }
+
+        private static ClientProtocol SniffProtocol(byte firstByte)
+        {
+            // Legacy clients open with bare JSON: '{', possibly preceded by
+            // whitespace. A frame header's first byte is the high byte of the
+            // message length, which MaxFrameSize caps at 0x04 — below '{'
+            // (0x7B) and every whitespace byte (0x09, 0x0A, 0x0D, 0x20).
+            if (firstByte == (byte)'{' || firstByte == (byte)' ' ||
+                firstByte == (byte)'\t' || firstByte == (byte)'\r' ||
+                firstByte == (byte)'\n')
+            {
+                return ClientProtocol.Legacy;
+            }
+            return ClientProtocol.Framed;
+        }
+
+        private static bool TryExtractFrame(List<byte> pending, out JObject command)
+        {
+            command = null;
+            if (pending.Count < FrameHeaderSize) return false;
+
+            int frameLength = (pending[0] << 24) | (pending[1] << 16) |
+                              (pending[2] << 8) | pending[3];
+            if (frameLength <= 0 || frameLength > MaxFrameSize)
+            {
+                // Hard protocol violation; the caller logs and drops the
+                // connection rather than guessing where the next frame starts.
+                throw new InvalidOperationException(
+                    $"Invalid frame length {frameLength} (limit {MaxFrameSize} bytes)");
+            }
+
+            if (pending.Count < FrameHeaderSize + frameLength) return false;
+
+            string json = Encoding.UTF8.GetString(
+                pending.GetRange(FrameHeaderSize, frameLength).ToArray());
+            pending.RemoveRange(0, FrameHeaderSize + frameLength);
+            command = JObject.Parse(json);
+            return true;
+        }
+
+        private void DispatchCommand(JObject command, NetworkStream stream, bool framed)
+        {
+            // Execute command on Rhino's main thread. Posts are processed in
+            // order, so pipelined framed commands get their responses in the
+            // order the commands were sent.
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    JObject response = ExecuteCommand(command);
+                    string responseJson = JsonConvert.SerializeObject(response);
+
+                    try
+                    {
+                        WriteMessage(stream, responseJson, framed);
+                    }
+                    catch
+                    {
+                        RhinoApp.WriteLine("Failed to send response - client disconnected");
+                    }
+                }
+                catch (Exception e)
+                {
+                    RhinoApp.WriteLine($"Error executing command: {e.Message}");
+                    try
+                    {
+                        JObject errorResponse = new JObject
+                        {
+                            ["status"] = "error",
+                            ["message"] = e.Message
+                        };
+
+                        WriteMessage(stream, errorResponse.ToString(), framed);
+                    }
+                    catch
+                    {
+                        // Ignore send errors
+                    }
+                }
+            }));
+        }
+
+        private static void WriteMessage(NetworkStream stream, string json, bool framed)
+        {
+            byte[] payload = Encoding.UTF8.GetBytes(json);
+            if (!framed)
+            {
+                stream.Write(payload, 0, payload.Length);
+                return;
+            }
+
+            // One write for header + payload keeps the frame contiguous.
+            byte[] message = new byte[FrameHeaderSize + payload.Length];
+            message[0] = (byte)((payload.Length >> 24) & 0xFF);
+            message[1] = (byte)((payload.Length >> 16) & 0xFF);
+            message[2] = (byte)((payload.Length >> 8) & 0xFF);
+            message[3] = (byte)(payload.Length & 0xFF);
+            Buffer.BlockCopy(payload, 0, message, FrameHeaderSize, payload.Length);
+            stream.Write(message, 0, message.Length);
         }
 
         private JObject ExecuteCommand(JObject command)

--- a/plugin/RhinoMCPServer.cs
+++ b/plugin/RhinoMCPServer.cs
@@ -217,8 +217,42 @@ namespace RhinoMCPPlugin
                                 // Drain every complete frame in the buffer so
                                 // pipelined commands all execute in order
                                 // instead of wedging the connection.
-                                while (TryExtractFrame(pending, out JObject framedCommand))
+                                while (TryExtractFrame(pending, out string framedJson))
                                 {
+                                    JObject framedCommand;
+                                    try
+                                    {
+                                        framedCommand = JObject.Parse(framedJson);
+                                    }
+                                    catch (JsonException ex)
+                                    {
+                                        // The frame was well-formed (its length
+                                        // matched) but the payload isn't valid
+                                        // JSON. Framing already located the next
+                                        // frame, so answer this one with an error
+                                        // and keep the connection instead of
+                                        // dropping every command queued behind it.
+                                        // Routed through the UI thread like every
+                                        // other write so responses stay
+                                        // single-writer and in send order.
+                                        string detail = ex.Message;
+                                        RhinoApp.InvokeOnUiThread(new Action(() =>
+                                        {
+                                            try
+                                            {
+                                                WriteMessage(stream, new JObject
+                                                {
+                                                    ["status"] = "error",
+                                                    ["message"] = $"Invalid JSON in framed message: {detail}"
+                                                }.ToString(), framed: true);
+                                            }
+                                            catch
+                                            {
+                                                RhinoApp.WriteLine("Failed to send error response - client disconnected");
+                                            }
+                                        }));
+                                        continue;
+                                    }
                                     DispatchCommand(framedCommand, stream, framed: true);
                                 }
                             }
@@ -286,27 +320,32 @@ namespace RhinoMCPPlugin
             return ClientProtocol.Framed;
         }
 
-        private static bool TryExtractFrame(List<byte> pending, out JObject command)
+        private static bool TryExtractFrame(List<byte> pending, out string payloadJson)
         {
-            command = null;
+            // Frame de-chunking only: pulls the bytes of one complete frame off
+            // the buffer and returns them as a string. JSON parsing happens in
+            // the caller, on purpose — a well-framed message whose payload is
+            // bad JSON should be a per-message error, not a dropped connection,
+            // and that's only recoverable once the frame bytes are consumed.
+            payloadJson = null;
             if (pending.Count < FrameHeaderSize) return false;
 
             int frameLength = (pending[0] << 24) | (pending[1] << 16) |
                               (pending[2] << 8) | pending[3];
             if (frameLength <= 0 || frameLength > MaxFrameSize)
             {
-                // Hard protocol violation; the caller logs and drops the
-                // connection rather than guessing where the next frame starts.
+                // A bad length means framing sync is lost: we can't tell where
+                // the next frame starts, so this one stays fatal. The caller
+                // logs and drops the connection.
                 throw new InvalidOperationException(
                     $"Invalid frame length {frameLength} (limit {MaxFrameSize} bytes)");
             }
 
             if (pending.Count < FrameHeaderSize + frameLength) return false;
 
-            string json = Encoding.UTF8.GetString(
+            payloadJson = Encoding.UTF8.GetString(
                 pending.GetRange(FrameHeaderSize, frameLength).ToArray());
             pending.RemoveRange(0, FrameHeaderSize + frameLength);
-            command = JObject.Parse(json);
             return true;
         }
 

--- a/server/src/rhinomcp/server.py
+++ b/server/src/rhinomcp/server.py
@@ -67,6 +67,14 @@ if RHINO_DEBUG:
     logger.info("Debug mode enabled")
 
 
+# Wire framing: every message in both directions is a 4-byte big-endian length
+# header followed by that many bytes of UTF-8 JSON. The cap below bounds memory
+# per frame; it also doubles as cross-version detection, since a legacy
+# unframed response starts with '{' (0x7B) and would decode as a ~2 GB length.
+FRAME_HEADER_SIZE = 4
+MAX_FRAME_SIZE = 64 * 1024 * 1024
+
+
 READONLY_RETRY_COMMANDS = {
     "get_object_info",
     "get_object_attributes",
@@ -146,64 +154,55 @@ class RhinoConnection:
             finally:
                 self.sock = None
 
-    def receive_full_response(self, sock, buffer_size=8192):
-        """Receive the complete response, potentially in multiple chunks.
+    def _recv_exact(self, sock, num_bytes, buffer_size=8192):
+        """Receive exactly num_bytes from sock.
 
-        Uses incremental parsing to avoid O(n^2) JSON parsing overhead.
+        Raises ConnectionResetError if the peer closes mid-message; lets
+        socket.timeout propagate so the caller's timeout handling applies.
         """
-        accumulated = ""
-        decoder = json.JSONDecoder()
+        received = bytearray()
+        while len(received) < num_bytes:
+            chunk = sock.recv(min(buffer_size, num_bytes - len(received)))
+            if not chunk:
+                raise ConnectionResetError(
+                    "Connection closed mid-message "
+                    f"({len(received)}/{num_bytes} bytes received)"
+                )
+            received.extend(chunk)
+        return bytes(received)
+
+    def receive_full_response(self, sock, buffer_size=8192):
+        """Receive one length-prefixed response frame.
+
+        Every message on the wire is a 4-byte big-endian length header followed
+        by that many bytes of UTF-8 JSON. Reading exact byte counts means
+        message boundaries are never guessed: back-to-back responses can't
+        bleed into one read, and a frame split across TCP segments is simply
+        read until complete.
+        """
         sock.settimeout(RHINO_TIMEOUT)
 
-        try:
-            while True:
-                try:
-                    chunk = sock.recv(buffer_size)
-                    if not chunk:
-                        if not accumulated:
-                            raise ConnectionResetError(
-                                "Connection closed before receiving any data"
-                            )
-                        break
-
-                    accumulated += chunk.decode("utf-8")
-
-                    # Only attempt parsing when we see a closing brace (optimization)
-                    if accumulated.rstrip().endswith("}"):
-                        try:
-                            # raw_decode returns (obj, end_index) - more efficient for streaming
-                            decoder.raw_decode(accumulated)
-                            logger.info(
-                                f"Received complete response ({len(accumulated)} bytes)"
-                            )
-                            return accumulated.encode("utf-8")
-                        except json.JSONDecodeError:
-                            # Incomplete JSON, continue receiving
-                            continue
-                except socket.timeout:
-                    logger.warning("Socket timeout during chunked receive")
-                    break
-                except (ConnectionError, BrokenPipeError, ConnectionResetError) as e:
-                    logger.error(f"Socket connection error during receive: {str(e)}")
-                    raise
-        except socket.timeout:
-            logger.warning("Socket timeout during chunked receive")
-        except Exception as e:
-            logger.error(f"Error during receive: {str(e)}")
-            raise
-
-        # Try to use what we have
-        if accumulated:
-            logger.info(
-                f"Returning data after receive completion ({len(accumulated)} bytes)"
+        header = self._recv_exact(sock, FRAME_HEADER_SIZE, buffer_size)
+        if header.startswith(b"{"):
+            # Bare JSON where a header should be: the installed plugin
+            # predates framing. Fail actionably instead of treating '{"st'
+            # as a ~2 GB length.
+            raise Exception(
+                "Rhino sent an unframed response: the installed rhinomcp "
+                "plugin predates length-prefixed framing. Update the plugin "
+                "to match this server version."
             )
-            try:
-                decoder.raw_decode(accumulated)
-                return accumulated.encode("utf-8")
-            except json.JSONDecodeError:
-                raise Exception("Incomplete JSON response received")
-        else:
-            raise Exception("No data received")
+
+        frame_length = int.from_bytes(header, "big")
+        if frame_length <= 0 or frame_length > MAX_FRAME_SIZE:
+            raise Exception(
+                f"Invalid response frame length {frame_length} from Rhino "
+                f"(limit {MAX_FRAME_SIZE} bytes)."
+            )
+
+        payload = self._recv_exact(sock, frame_length, buffer_size)
+        logger.info(f"Received complete response ({len(payload)} bytes)")
+        return payload
 
     def send_command(
         self, command_type: str, params: Dict[str, Any] = {}
@@ -277,12 +276,14 @@ class RhinoConnection:
             if self.sock is None:
                 raise Exception("Socket is not connected")
 
-            # Send the command
+            # Send the command as one length-prefixed frame
             command_json = json.dumps(command)
             logger.debug(
                 f"Raw command JSON ({len(command_json)} bytes): {command_json[:500]}..."
             )
-            self.sock.sendall(command_json.encode("utf-8"))
+            command_bytes = command_json.encode("utf-8")
+            header = len(command_bytes).to_bytes(FRAME_HEADER_SIZE, "big")
+            self.sock.sendall(header + command_bytes)
             logger.debug("Command sent, waiting for response...")
 
             # Set a timeout for receiving

--- a/server/tests/mock_rhino_server.py
+++ b/server/tests/mock_rhino_server.py
@@ -88,25 +88,82 @@ class MockRhinoServer:
                 if self.running:
                     print(f"Server error: {e}")
 
+    # Mirrors the plugin's wire protocol (RhinoMCPServer.cs): messages are a
+    # 4-byte big-endian length header plus UTF-8 JSON in both directions;
+    # legacy clients that open with bare JSON ('{' or whitespace) get the old
+    # unframed behavior for the whole connection.
+    FRAME_HEADER_SIZE = 4
+    MAX_FRAME_SIZE = 64 * 1024 * 1024
+    _LEGACY_FIRST_BYTES = b"{ \t\r\n"
+
     def _handle_client(self, client_socket: socket.socket):
-        """Handle a client connection."""
+        """Handle a client connection, sniffing framed vs legacy protocol."""
+        pending = bytearray()
+        framed: Optional[bool] = None
         try:
             while self.running:
                 data = client_socket.recv(65536)
                 if not data:
                     break
+                pending.extend(data)
 
-                try:
-                    command = json.loads(data.decode('utf-8'))
-                    response = self._process_command(command)
-                    client_socket.sendall(json.dumps(response).encode('utf-8'))
-                except json.JSONDecodeError as e:
-                    error_response = {"status": "error", "message": f"Invalid JSON: {e}"}
-                    client_socket.sendall(json.dumps(error_response).encode('utf-8'))
+                if framed is None:
+                    framed = pending[0:1] not in [
+                        bytes([b]) for b in self._LEGACY_FIRST_BYTES
+                    ]
+
+                if framed:
+                    # Drain every complete frame so pipelined commands all
+                    # execute, in order — same as the plugin.
+                    while len(pending) >= self.FRAME_HEADER_SIZE:
+                        frame_length = int.from_bytes(
+                            pending[: self.FRAME_HEADER_SIZE], "big"
+                        )
+                        if frame_length <= 0 or frame_length > self.MAX_FRAME_SIZE:
+                            raise ValueError(
+                                f"Invalid frame length {frame_length}"
+                            )
+                        if len(pending) < self.FRAME_HEADER_SIZE + frame_length:
+                            break
+                        payload = bytes(
+                            pending[
+                                self.FRAME_HEADER_SIZE : self.FRAME_HEADER_SIZE
+                                + frame_length
+                            ]
+                        )
+                        del pending[: self.FRAME_HEADER_SIZE + frame_length]
+                        self._respond(client_socket, payload, framed=True)
+                else:
+                    # Legacy: try the whole accumulation, wait for more on
+                    # incomplete JSON.
+                    try:
+                        json.loads(pending.decode("utf-8"))
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        continue
+                    payload = bytes(pending)
+                    pending.clear()
+                    self._respond(client_socket, payload, framed=False)
         except Exception as e:
             print(f"Client handler error: {e}")
         finally:
             client_socket.close()
+
+    def _respond(self, client_socket: socket.socket, payload: bytes, framed: bool):
+        """Process one command payload and write the response in the
+        connection's protocol."""
+        try:
+            command = json.loads(payload.decode("utf-8"))
+            response = self._process_command(command)
+        except json.JSONDecodeError as e:
+            response = {"status": "error", "message": f"Invalid JSON: {e}"}
+
+        body = json.dumps(response).encode("utf-8")
+        if framed:
+            client_socket.sendall(
+                len(body).to_bytes(self.FRAME_HEADER_SIZE, "big") + body
+            )
+        else:
+            client_socket.sendall(body)
 
     def _process_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
         """Process a command and return a response."""

--- a/server/tests/test_connection.py
+++ b/server/tests/test_connection.py
@@ -9,6 +9,24 @@ import socket
 from unittest.mock import patch, MagicMock
 
 
+def frame(payload: bytes) -> bytes:
+    """Wrap a payload in the wire protocol's 4-byte big-endian length header."""
+    return len(payload).to_bytes(4, "big") + payload
+
+
+def buffered_recv(wire_bytes: bytes):
+    """A recv side_effect that serves wire_bytes honoring the requested byte
+    count, like a real socket buffer. Returns b"" once drained (peer close)."""
+    buffer = bytearray(wire_bytes)
+
+    def recv(n):
+        chunk = bytes(buffer[:n])
+        del buffer[:n]
+        return chunk
+
+    return recv
+
+
 class TestRhinoConnection:
     """Tests for the RhinoConnection class."""
 
@@ -80,33 +98,34 @@ class TestReceiveFullResponse:
     """Tests for the receive_full_response method."""
 
     def test_receive_complete_json(self):
-        """Test receiving a complete JSON response in one chunk."""
+        """Test receiving a complete framed response."""
         from rhinomcp.server import RhinoConnection
 
         conn = RhinoConnection(host="127.0.0.1", port=1999)
 
         mock_sock = MagicMock()
         response = {"status": "success", "result": {"id": "123"}}
-        mock_sock.recv.return_value = json.dumps(response).encode("utf-8")
+        wire = frame(json.dumps(response).encode("utf-8"))
+        mock_sock.recv.side_effect = buffered_recv(wire)
 
         result = conn.receive_full_response(mock_sock)
 
         assert json.loads(result.decode("utf-8")) == response
 
     def test_receive_chunked_json(self):
-        """Test receiving JSON response in multiple chunks."""
+        """Test receiving a frame split across multiple TCP segments."""
         from rhinomcp.server import RhinoConnection
 
         conn = RhinoConnection(host="127.0.0.1", port=1999)
 
         mock_sock = MagicMock()
         response = {"status": "success", "result": {"data": "x" * 1000}}
-        full_json = json.dumps(response).encode("utf-8")
+        wire = frame(json.dumps(response).encode("utf-8"))
 
-        # Split into chunks
-        chunk1 = full_json[:50]
-        chunk2 = full_json[50:]
-        mock_sock.recv.side_effect = [chunk1, chunk2]
+        # Header alone, then the body dribbling in: sockets may return fewer
+        # bytes than requested.
+        chunks = [wire[:4], wire[4:54], wire[54:]]
+        mock_sock.recv.side_effect = chunks
 
         result = conn.receive_full_response(mock_sock)
 
@@ -122,6 +141,73 @@ class TestReceiveFullResponse:
         mock_sock.recv.return_value = b""
 
         with pytest.raises(Exception, match="Connection closed"):
+            conn.receive_full_response(mock_sock)
+
+
+class TestWireFraming:
+    """Length-prefixed framing: message boundaries are read, not guessed."""
+
+    def test_consecutive_responses_do_not_bleed(self):
+        """Two responses back-to-back in the receive buffer is legal TCP.
+        The old endswith-'}' + raw_decode heuristic passed both to one
+        json.loads, which raised 'Extra data' and lost the second response.
+        Framed reads return exactly one message per call."""
+        from rhinomcp.server import RhinoConnection
+
+        conn = RhinoConnection(host="127.0.0.1", port=1999)
+
+        resp1 = json.dumps({"status": "success", "result": {"sequence": 1}})
+        resp2 = json.dumps({"status": "success", "result": {"sequence": 2}})
+        wire = frame(resp1.encode("utf-8")) + frame(resp2.encode("utf-8"))
+
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = buffered_recv(wire)
+
+        first = conn.receive_full_response(mock_sock)
+        second = conn.receive_full_response(mock_sock)
+
+        assert json.loads(first)["result"]["sequence"] == 1
+        assert json.loads(second)["result"]["sequence"] == 2
+
+    def test_unframed_response_raises_actionable_error(self):
+        """An old plugin replies with bare JSON where the header should be.
+        That must fail with update guidance, not a bogus 2 GB frame length."""
+        from rhinomcp.server import RhinoConnection
+
+        conn = RhinoConnection(host="127.0.0.1", port=1999)
+
+        bare = json.dumps({"status": "success", "result": {}}).encode("utf-8")
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = buffered_recv(bare)
+
+        with pytest.raises(Exception, match="predates length-prefixed framing"):
+            conn.receive_full_response(mock_sock)
+
+    def test_oversized_frame_rejected(self):
+        from rhinomcp.server import MAX_FRAME_SIZE, RhinoConnection
+
+        conn = RhinoConnection(host="127.0.0.1", port=1999)
+
+        header = (MAX_FRAME_SIZE + 1).to_bytes(4, "big")
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = buffered_recv(header)
+
+        with pytest.raises(Exception, match="Invalid response frame length"):
+            conn.receive_full_response(mock_sock)
+
+    def test_connection_closed_mid_frame_raises(self):
+        """EOF after the header but before the body completes must surface as
+        a connection error, not hang or return a truncated message."""
+        from rhinomcp.server import RhinoConnection
+
+        conn = RhinoConnection(host="127.0.0.1", port=1999)
+
+        body = json.dumps({"status": "success", "result": {}}).encode("utf-8")
+        wire = frame(body)[: 4 + len(body) // 2]  # header + half the body
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = buffered_recv(wire)
+
+        with pytest.raises(ConnectionError, match="mid-message"):
             conn.receive_full_response(mock_sock)
 
 
@@ -199,9 +285,9 @@ class TestRuntimeValidation:
 
         mock_sock = MagicMock()
         mock_socket_class.return_value = mock_sock
-        mock_sock.recv.return_value = json.dumps(
-            {"status": "success", "result": {}}
-        ).encode("utf-8")
+        mock_sock.recv.side_effect = buffered_recv(
+            frame(json.dumps({"status": "success", "result": {}}).encode("utf-8"))
+        )
 
         conn = RhinoConnection(host="127.0.0.1", port=1999)
         conn.connect()
@@ -397,7 +483,9 @@ class TestSendCommand:
         mock_socket_class.return_value = mock_sock
 
         response = {"status": "success", "result": {"name": "Box1", "id": "abc-123"}}
-        mock_sock.recv.return_value = json.dumps(response).encode("utf-8")
+        mock_sock.recv.side_effect = buffered_recv(
+            frame(json.dumps(response).encode("utf-8"))
+        )
 
         conn = RhinoConnection(host="127.0.0.1", port=1999)
         conn.connect()
@@ -409,9 +497,11 @@ class TestSendCommand:
 
         assert result == {"name": "Box1", "id": "abc-123"}
 
-        # Verify the command was sent correctly
+        # Verify the command went out as one frame: 4-byte big-endian length
+        # header followed by the JSON payload.
         sent_data = mock_sock.sendall.call_args[0][0]
-        sent_command = json.loads(sent_data.decode("utf-8"))
+        assert int.from_bytes(sent_data[:4], "big") == len(sent_data) - 4
+        sent_command = json.loads(sent_data[4:].decode("utf-8"))
         assert sent_command["type"] == "create_object"
         assert sent_command["params"]["type"] == "BOX"
 
@@ -424,7 +514,9 @@ class TestSendCommand:
         mock_socket_class.return_value = mock_sock
 
         response = {"status": "error", "message": "Object not found"}
-        mock_sock.recv.return_value = json.dumps(response).encode("utf-8")
+        mock_sock.recv.side_effect = buffered_recv(
+            frame(json.dumps(response).encode("utf-8"))
+        )
 
         conn = RhinoConnection(host="127.0.0.1", port=1999)
         conn.connect()
@@ -447,8 +539,8 @@ class TestSendCommand:
         conn = RhinoConnection(host="127.0.0.1", port=1999)
         conn.connect()
 
-        # Socket timeout leads to "No data received" which is wrapped as communication error
-        with pytest.raises(Exception, match="Communication error with Rhino"):
+        # Receive timeouts propagate to the dedicated timeout handler
+        with pytest.raises(Exception, match="Timeout waiting for Rhino response"):
             conn.send_command(
                 "create_object",
                 {"type": "BOX", "params": {"width": 1, "length": 1, "height": 1}},
@@ -485,9 +577,13 @@ class TestSendCommand:
         first_sock = MagicMock()
         first_sock.recv.return_value = b""
         second_sock = MagicMock()
-        second_sock.recv.return_value = json.dumps(
-            {"status": "success", "result": {"found_count": 1}}
-        ).encode("utf-8")
+        second_sock.recv.side_effect = buffered_recv(
+            frame(
+                json.dumps(
+                    {"status": "success", "result": {"found_count": 1}}
+                ).encode("utf-8")
+            )
+        )
         mock_socket_class.side_effect = [first_sock, second_sock]
 
         conn = RhinoConnection(host="127.0.0.1", port=1999)

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -590,3 +590,35 @@ class TestWireProtocol:
         # Bare JSON back: the first byte is '{', not a length header.
         assert data[0:1] == b"{"
         assert response["status"] == "success"
+
+    def test_malformed_frame_gets_error_and_connection_survives(self, mock_server):
+        """A well-framed message carrying bad JSON must not take the whole
+        connection down with it. Framing pins where the next frame starts, so
+        the bad one gets an error response and the command queued behind it is
+        still answered. This pins the contract the plugin has to meet."""
+        good1 = json.dumps({"type": "get_document_summary", "params": {}}).encode("utf-8")
+        bad = b"{not valid json"
+        good2 = json.dumps({"type": "get_objects", "params": {}}).encode("utf-8")
+        wire = (
+            len(good1).to_bytes(4, "big") + good1
+            + len(bad).to_bytes(4, "big") + bad
+            + len(good2).to_bytes(4, "big") + good2
+        )
+
+        sock = socket.create_connection(("127.0.0.1", 19999), timeout=5)
+        try:
+            sock.sendall(wire)
+            first = self._read_frame(sock)
+            second = self._read_frame(sock)
+            third = self._read_frame(sock)
+        finally:
+            sock.close()
+
+        # The good commands before and after the bad frame both succeed, in
+        # order; the bad one comes back as an error rather than a dropped
+        # connection (which would hang _read_frame on the third reply).
+        assert first["status"] == "success"
+        assert "object_count" in first["result"]
+        assert second["status"] == "error"
+        assert third["status"] == "success"
+        assert "objects" in third["result"]

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -4,7 +4,9 @@ Integration tests using the mock Rhino server.
 These tests verify the full flow from MCP tools through to the server response.
 """
 
+import json
 import pytest
+import socket
 import time
 from tests.mock_rhino_server import MockRhinoServer
 
@@ -519,3 +521,72 @@ class TestAdvancedGeometry:
         # image_data must be valid base64 the wrapper can decode.
         base64.b64decode(result["image_data"])
         assert result["viewport_name"] == "perspective"
+
+
+class TestWireProtocol:
+    """Wire-level tests against the mock server, which mirrors the plugin's
+    framing logic: framed protocol for new clients, legacy bare JSON for old
+    ones, decided by the first byte of the connection."""
+
+    def _read_frame(self, sock):
+        header = b""
+        while len(header) < 4:
+            chunk = sock.recv(4 - len(header))
+            assert chunk, "connection closed mid-header"
+            header += chunk
+        length = int.from_bytes(header, "big")
+        body = b""
+        while len(body) < length:
+            chunk = sock.recv(length - len(body))
+            assert chunk, "connection closed mid-body"
+            body += chunk
+        return json.loads(body.decode("utf-8"))
+
+    def test_pipelined_framed_commands_all_answered_in_order(self, mock_server):
+        """The regression that motivated framing: two commands in one TCP
+        write. The old whole-buffer JObject.Parse approach could never parse
+        the concatenation, wedging the connection with both commands lost.
+        With framing both execute and answer in order."""
+        cmd1 = json.dumps({"type": "get_document_summary", "params": {}}).encode("utf-8")
+        cmd2 = json.dumps({"type": "get_objects", "params": {}}).encode("utf-8")
+        wire = (
+            len(cmd1).to_bytes(4, "big") + cmd1
+            + len(cmd2).to_bytes(4, "big") + cmd2
+        )
+
+        sock = socket.create_connection(("127.0.0.1", 19999), timeout=5)
+        try:
+            sock.sendall(wire)
+            first = self._read_frame(sock)
+            second = self._read_frame(sock)
+        finally:
+            sock.close()
+
+        assert first["status"] == "success"
+        assert "object_count" in first["result"]  # document summary
+        assert second["status"] == "success"
+        assert "objects" in second["result"]  # get_objects result
+
+    def test_legacy_unframed_client_still_works(self, mock_server):
+        """A pre-framing client sends bare JSON and expects bare JSON back.
+        The first-byte sniff must route it onto the legacy path."""
+        cmd = json.dumps({"type": "get_document_summary", "params": {}}).encode("utf-8")
+
+        sock = socket.create_connection(("127.0.0.1", 19999), timeout=5)
+        try:
+            sock.sendall(cmd)
+            sock.settimeout(5)
+            data = b""
+            while True:
+                data += sock.recv(65536)
+                try:
+                    response = json.loads(data.decode("utf-8"))
+                    break
+                except json.JSONDecodeError:
+                    continue
+        finally:
+            sock.close()
+
+        # Bare JSON back: the first byte is '{', not a length header.
+        assert data[0:1] == b"{"
+        assert response["status"] == "success"


### PR DESCRIPTION
Follow-up to #31. This replaces the parse-and-hope message boundaries with real framing on both sides of the TCP bridge: every message is a 4-byte big-endian length header followed by UTF-8 JSON.

What changes in behavior (the repros for the old failures are in the issue):

- Two commands landing in one read no longer wedge the connection. The plugin drains every complete frame in its buffer and runs them in order, so pipelining just works now.
- Two responses landing in one read no longer fail a command that succeeded. The client reads exactly one frame per response, nothing bleeds, nothing gets lost.
- A frame split across TCP segments gets read until complete instead of being re-parsed on every chunk.

The part I most wanted to get right is back-compat. Existing unframed clients keep working: the plugin sniffs the first byte of each connection, and bare JSON (`{` or whitespace) keeps that connection on the old protocol, old parse semantics and unframed responses included. A frame header's first byte can't collide with those because frames are capped at 64 MB. The cap also bounds memory per message and turns a garbage header into an immediate logged disconnect instead of a giant allocation attempt.

Server and plugin ship together from this repo, so a normal release updates both halves at once. The rough edge that's left is a new server against an old plugin: the old plugin can't parse framed bytes and never answers, so the client times out instead of getting a targeted error. The client does detect the reverse shape (a bare `{` where a header should be) and says to update the plugin. A version handshake would close that gap completely, but it felt like scope creep here. I'll do it as a follow-up if you want it.

Code notes: the inline lambda in HandleClient moved into a DispatchCommand helper shared by both protocols, with WriteMessage picking framed or bare output per connection. On the Python side receive_full_response shrank from a heuristic loop down to reading exactly header then body. The mock Rhino server in the tests mirrors the plugin's sniff and framing, so the integration suite exercises the same protocol decisions as the real plugin.

There are two kinds of malformed input and I treat them differently on purpose. A bad frame length means framing sync is lost, we can't tell where the next frame begins, so that drops the connection with a logged error. But a well-framed message whose payload just isn't valid JSON is recoverable: framing already located the next frame, so that one message gets an error response and the connection stays up to handle whatever was pipelined behind it. The second commit splits frame extraction from JSON parsing in the plugin to make that possible, since otherwise one bad payload would take out every command queued after it, which is the same data-loss problem framing exists to kill. The error response goes through the UI thread like every other write, so responses stay single-writer and in send order.

Testing:
- `pytest` in `server/`, 158 passing. New tests cover back-to-back responses both delivered (the data-loss case), frames split across reads, unframed-plugin detection, oversized frames, EOF mid-frame, pipelined commands answered in order through the mock, a legacy bare-JSON client getting bare JSON back, and a malformed framed message getting an error reply while the commands before and after it both still succeed
- `python contracts/test_schemas.py`, all passing
- `dotnet build plugin/rhinomcp.sln -c Release`, clean
- I also tested the compiled C# directly, not just that it builds: a small reflection harness loads the built rhinomcp.rhp and drives SniffProtocol, TryExtractFrame and WriteMessage. Sniff byte battery, partial header and partial body kept in the buffer, two pipelined frames extracted in order, multi-byte UTF-8 intact, a malformed-JSON frame still extracted cleanly so the caller can answer it instead of dropping, negative/zero/oversized lengths rejected, and WriteMessage checked byte for byte over a real loopback socket pair in both modes
- back-compat against real old code, not a simulation: the pre-framing RhinoConnection from current main, loaded side by side, talks to the new server fine, including running at the same time as a framed client on another connection, and with a command split across two writes
- against live Rhino 8 with the current unframed plugin, reproduced both failure modes from the issue before writing the fix
- against live Rhino 8 with this build loaded: a framed command round-trips, a legacy bare-JSON client on the same listener gets unframed responses, and the bundled client works end to end
- and a harder live check on the same build: a burst of 60 framed commands in one write, with a malformed frame planted in the middle, all came back in order, the bad one as an error and the rest fine, and that held with several connections firing the same burst at once

Docs updated in IMPLEMENTATION.md and contracts/README.md to describe the framing and the legacy fallback.

To see it yourself with this build loaded: run `mcpstart`, then send two framed get_document_summary commands in a single sendall on one socket, both come back in order. Send bare JSON on a fresh socket and you get bare JSON back.