### PR TITLE
Surface bounding_box and geometry in create/modify responses

### DIFF
--- a/server/src/rhinomcp/tools/create_object.py
+++ b/server/src/rhinomcp/tools/create_object.py
@@ -82,7 +82,9 @@ def create_object(
     - closed: ([bool, bool], optional) Two booleans defining if the surface is closed in the u,v directions
     
     Returns:
-    A dict with success, id, name, type, message — exceptions propagate as MCP tool errors.
+    A dict with success, id, name, type, message, plus bounding_box (the new
+    object's axis-aligned extent) and, for curve-like types, geometry — each
+    present only when the plugin reported it. Exceptions propagate as MCP tool errors.
     
     Examples of params:
     - POINT: {"x": 0, "y": 0, "z": 0}
@@ -108,10 +110,21 @@ def create_object(
     # Errors propagate so MCP clients see a real tool error instead of a
     # successful string starting with "Error ...".
     result = rhino.send_command("create_object", command_params)
-    return {
+    response: Dict[str, Any] = {
         "success": True,
         "id": result.get("id"),
         "name": result.get("name"),
         "type": result.get("type", type),
         "message": f"Created {type} object: {result.get('name')}",
     }
+    # Surface the spatial feedback the plugin already serialized for the new
+    # object — its axis-aligned bounding box, plus the geometry block for
+    # curve-like types — instead of discarding it. This lets the client see
+    # where the object landed and how big it is without a follow-up query.
+    # Each is added only when present so primitives that carry no geometry
+    # block keep a stable response shape.
+    if result.get("bounding_box") is not None:
+        response["bounding_box"] = result["bounding_box"]
+    if result.get("geometry") is not None:
+        response["geometry"] = result["geometry"]
+    return response

--- a/server/src/rhinomcp/tools/modify_object.py
+++ b/server/src/rhinomcp/tools/modify_object.py
@@ -28,7 +28,10 @@ def modify_object(
     - scale: Optional [x, y, z] scale factors
     - visible: Optional boolean to set visibility
 
-    Returns a dict with success/id/name/message. Errors propagate as MCP tool errors.
+    Returns a dict with success, id, name, message, plus bounding_box — the
+    object's new post-edit axis-aligned extent — and, for curve-like types,
+    geometry, each present only when the plugin reported it. Errors propagate
+    as MCP tool errors.
     """
     rhino = get_rhino_connection()
 
@@ -43,9 +46,19 @@ def modify_object(
     if visible is not None: params["visible"] = visible
 
     result = rhino.send_command("modify_object", params)
-    return {
+    response: Dict[str, Any] = {
         "success": True,
         "id": result.get("id"),
         "name": result.get("name"),
         "message": f"Modified object: {result.get('name')}",
     }
+    # The plugin re-serializes the object after the edit, so bounding_box here
+    # reflects the NEW post-transform extent — exactly what a client needs to
+    # confirm a translate/scale landed where intended, without re-querying.
+    # geometry (curve-like types) comes along the same way. Each is added only
+    # when present to keep the response shape stable.
+    if result.get("bounding_box") is not None:
+        response["bounding_box"] = result["bounding_box"]
+    if result.get("geometry") is not None:
+        response["geometry"] = result["geometry"]
+    return response

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -519,3 +519,55 @@ class TestAdvancedGeometry:
         # image_data must be valid base64 the wrapper can decode.
         base64.b64decode(result["image_data"])
         assert result["viewport_name"] == "perspective"
+
+
+class TestPerceptionPassthrough:
+    """End-to-end: the create/modify tool wrappers must surface the spatial
+    feedback (bounding_box) the plugin serializes, through the full
+    wrapper -> socket -> plugin -> wrapper path. This is the CI-runnable
+    end-to-end of Scene Perception Layer stage 0, against the mock whose
+    create/modify responses mirror the plugin's Serializer.RhinoObject shape.
+
+    The wrappers' get_rhino_connection is monkeypatched to a connection aimed
+    explicitly at the mock port. That keeps the test hermetic: it can never
+    fall back to a real Rhino on the default port (which would mutate a live
+    document), and it doesn't depend on module-reload ordering elsewhere in the
+    suite that can leave the wrapper's import-time binding pointed at the
+    default port.
+    """
+
+    def _mock_conn(self, monkeypatch):
+        from rhinomcp.server import RhinoConnection
+        import rhinomcp.tools.create_object as create_mod
+        import rhinomcp.tools.modify_object as modify_mod
+
+        conn = RhinoConnection(host="127.0.0.1", port=19999)
+        monkeypatch.setattr(create_mod, "get_rhino_connection", lambda: conn)
+        monkeypatch.setattr(modify_mod, "get_rhino_connection", lambda: conn)
+        return create_mod.create_object, modify_mod.modify_object
+
+    def test_create_wrapper_surfaces_bounding_box(self, mock_server, monkeypatch):
+        create_object, _ = self._mock_conn(monkeypatch)
+
+        result = create_object(
+            ctx=None, type="BOX", name="PerceptionBox",
+            params={"width": 1, "length": 1, "height": 1},
+        )
+
+        assert result["success"] is True
+        assert result["id"] is not None
+        # The bbox the plugin computed is now visible to the client end to end.
+        assert result["bounding_box"] == [[-1, -1, -1], [1, 1, 1]]
+
+    def test_modify_wrapper_surfaces_bounding_box(self, mock_server, monkeypatch):
+        create_object, modify_object = self._mock_conn(monkeypatch)
+
+        created = create_object(
+            ctx=None, type="BOX", name="ToMove",
+            params={"width": 1, "length": 1, "height": 1},
+        )
+        moved = modify_object(ctx=None, id=created["id"], translation=[5, 0, 0])
+
+        assert moved["success"] is True
+        # A modify now reports the object's extent rather than just id/name.
+        assert "bounding_box" in moved

--- a/server/tests/test_tools.py
+++ b/server/tests/test_tools.py
@@ -110,6 +110,75 @@ class TestCreateObjectTool:
         with pytest.raises(Exception, match="Connection failed"):
             create_object(ctx=None, type="BOX", params={"width": 1, "length": 1, "height": 1})
 
+    @patch('rhinomcp.tools.create_object.get_rhino_connection')
+    def test_create_surfaces_bounding_box(self, mock_get_conn):
+        """The plugin serializes the new object's bounding box; the wrapper must
+        pass it through instead of discarding it, so the client learns where the
+        object landed without a follow-up query."""
+        from rhinomcp.tools.create_object import create_object
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "id": "abc-123",
+            "name": "TestBox",
+            "type": "Brep",
+            "bounding_box": [[0, 0, 0], [1, 2, 3]],
+        }
+        mock_get_conn.return_value = mock_conn
+
+        result = create_object(
+            ctx=None, type="BOX", name="TestBox",
+            params={"width": 1, "length": 2, "height": 3},
+        )
+
+        assert result["bounding_box"] == [[0, 0, 0], [1, 2, 3]]
+        # Purely additive: existing fields are untouched.
+        assert result["success"] is True
+        assert result["id"] == "abc-123"
+        assert "geometry" not in result  # a box carries no geometry block
+
+    @patch('rhinomcp.tools.create_object.get_rhino_connection')
+    def test_create_surfaces_geometry_for_curve_like(self, mock_get_conn):
+        """Curve-like types (LINE here) carry a geometry block; it rides through too."""
+        from rhinomcp.tools.create_object import create_object
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "id": "line-1",
+            "name": "Edge",
+            "type": "LINE",
+            "bounding_box": [[0, 0, 0], [3, 4, 0]],
+            "geometry": {"start": [0, 0, 0], "end": [3, 4, 0]},
+        }
+        mock_get_conn.return_value = mock_conn
+
+        result = create_object(
+            ctx=None, type="LINE", name="Edge",
+            params={"start": [0, 0, 0], "end": [3, 4, 0]},
+        )
+
+        assert result["geometry"] == {"start": [0, 0, 0], "end": [3, 4, 0]}
+        assert result["bounding_box"] == [[0, 0, 0], [3, 4, 0]]
+
+    @patch('rhinomcp.tools.create_object.get_rhino_connection')
+    def test_create_omits_perception_fields_when_plugin_absent(self, mock_get_conn):
+        """If the plugin reports neither field (an older plugin, or a path that
+        doesn't serialize them), the response shape stays exactly as before —
+        no null keys leak in."""
+        from rhinomcp.tools.create_object import create_object
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {"id": "x", "name": "Y", "type": "BOX"}
+        mock_get_conn.return_value = mock_conn
+
+        result = create_object(
+            ctx=None, type="BOX", params={"width": 1, "length": 1, "height": 1},
+        )
+
+        assert "bounding_box" not in result
+        assert "geometry" not in result
+        assert result["id"] == "x"
+
 
 class TestCreateObjectsTool:
     """Tests for create_objects tool."""
@@ -190,6 +259,61 @@ class TestModifyObjectTool:
 
         call_args = mock_conn.send_command.call_args
         assert call_args[0][1]["new_color"] == [255, 128, 0]
+
+    @patch('rhinomcp.tools.modify_object.get_rhino_connection')
+    def test_modify_surfaces_new_bounding_box(self, mock_get_conn):
+        """The plugin re-serializes after the edit, so bounding_box is the NEW
+        post-transform extent. A translate must report the moved box — that is
+        the whole point of surfacing it."""
+        from rhinomcp.tools.modify_object import modify_object
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "id": "abc-123",
+            "name": "Moved",
+            "bounding_box": [[10, 20, 30], [11, 22, 33]],
+        }
+        mock_get_conn.return_value = mock_conn
+
+        result = modify_object(ctx=None, id="abc-123", translation=[10, 20, 30])
+
+        assert result["bounding_box"] == [[10, 20, 30], [11, 22, 33]]
+        assert result["success"] is True
+        assert result["id"] == "abc-123"
+
+    @patch('rhinomcp.tools.modify_object.get_rhino_connection')
+    def test_modify_surfaces_geometry(self, mock_get_conn):
+        from rhinomcp.tools.modify_object import modify_object
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "id": "line-1",
+            "name": "Edge",
+            "bounding_box": [[0, 0, 0], [5, 0, 0]],
+            "geometry": {"start": [0, 0, 0], "end": [5, 0, 0]},
+        }
+        mock_get_conn.return_value = mock_conn
+
+        result = modify_object(ctx=None, id="line-1", scale=[5, 1, 1])
+
+        assert result["geometry"] == {"start": [0, 0, 0], "end": [5, 0, 0]}
+        assert result["bounding_box"] == [[0, 0, 0], [5, 0, 0]]
+
+    @patch('rhinomcp.tools.modify_object.get_rhino_connection')
+    def test_modify_omits_perception_fields_when_plugin_absent(self, mock_get_conn):
+        """A rename carries no spatial change worth surfacing if the plugin
+        doesn't include it; the response stays minimal with no null keys."""
+        from rhinomcp.tools.modify_object import modify_object
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {"id": "abc-123", "name": "NewName"}
+        mock_get_conn.return_value = mock_conn
+
+        result = modify_object(ctx=None, id="abc-123", new_name="NewName")
+
+        assert "bounding_box" not in result
+        assert "geometry" not in result
+        assert result["name"] == "NewName"
 
 
 class TestObjectAttributesTools:


### PR DESCRIPTION
I noticed create_object and modify_object throw away data the plugin already computed. On the C# side both end up in Serializer.RhinoObject (create routes through ModifyObject, and modify re-serializes the object after the edit), so the response that comes back over the socket already includes the object's bounding box, and for curve-like types the geometry block. The Python wrappers then reduce all of that down to {success, id, name, message} and drop the rest.

The effect is that after I create a box or translate something, the client has to fire a second get_object_info just to find out where the thing actually ended up. The bounding box is the cheap, useful bit of feedback that answers "where did it land and how big is it," and it's already sitting in the response, just discarded before the client sees it.

This passes it through. create_object and modify_object now include bounding_box, plus geometry when the plugin sent one (lines, polylines, curves). Both are added only when present, so primitives that carry no geometry block keep the exact same shape, and when the plugin sends nothing new the responses are byte-identical to before.

I named the branch "perception stage 0" because this is the smallest first step of something I'd like to propose more fully if you're open to it, partly in answer to #25. The Grasshopper side already returns rich feedback (gh_build_graph hands back counts, what recomputed, timing, a summary), and the older Rhino-geometry side mostly returns nothing. I'd like to port that same feedback bar over to the Rhino side in small, independent steps. This PR is the no-risk warm-up: it only stops discarding what the plugin already produced. Happy to talk through the rest of the direction separately rather than front-load it here.

Backward compatibility: object_info.json already permits bounding_box and geometry and has no top-level additionalProperties:false, so this stays green under RHINO_MCP_VALIDATE in every mode.

Testing:
- pytest in server/, 159 passing. New tests cover the passthrough, the curve-geometry case, graceful omission when the plugin sends neither field (no null keys leak in), and that the existing fields are untouched. Plus two end-to-end tests that drive the wrappers through a real socket to the mock and assert the bounding box arrives; they are pinned to the mock port so they can never reach a real Rhino.
- python contracts/test_schemas.py, all passing
- ran it against live Rhino 8: created a box and got its real bounding box back, created a line and got its start/end geometry, then translated the box by [10, 0, 0] and watched the returned bounding box move with it (min x went from -1 to 9). That last one is the point of surfacing it on modify, the new post-transform extent comes back without a re-query.

Server-side Python only. No plugin or wire change.