### PR TITLE
Add an opt-in change-delta to mutating command responses

### DIFF
--- a/contracts/responses/change_delta.json
+++ b/contracts/responses/change_delta.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "change_delta.json",
+  "title": "ChangeDelta",
+  "description": "What changed in the document as a result of a mutating command. Attached as `_delta` on the command result when the client opts in (envelope include_delta=true). Created/deleted are exact id set differences; a modified count is intentionally absent since an in-place transform reuses the same id.",
+  "type": "object",
+  "properties": {
+    "created_ids": {
+      "type": "array",
+      "items": { "$ref": "../common/definitions.json#/$defs/guid" },
+      "description": "Object GUIDs present after the command but not before."
+    },
+    "deleted_ids": {
+      "type": "array",
+      "items": { "$ref": "../common/definitions.json#/$defs/guid" },
+      "description": "Object GUIDs present before the command but not after."
+    },
+    "count_before": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Object count before the command ran."
+    },
+    "count_after": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Object count after the command ran."
+    }
+  },
+  "required": ["created_ids", "deleted_ids", "count_before", "count_after"],
+  "additionalProperties": false
+}

--- a/contracts/responses/change_delta.json
+++ b/contracts/responses/change_delta.json
@@ -2,18 +2,18 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "change_delta.json",
   "title": "ChangeDelta",
-  "description": "What changed in the document as a result of a mutating command. Attached as `_delta` on the command result when the client opts in (envelope include_delta=true). Created/deleted are exact id set differences; a modified count is intentionally absent since an in-place transform reuses the same id.",
+  "description": "What changed in the document as a result of a mutating command. Attached as `_delta` on the command result when the client opts in (envelope include_delta=true). Counts are always exact; the created_ids/deleted_ids arrays are included only when small enough not to flood the response, and `truncated` is set when one was dropped. A modified count is intentionally absent since an in-place transform reuses the same id.",
   "type": "object",
   "properties": {
-    "created_ids": {
-      "type": "array",
-      "items": { "$ref": "../common/definitions.json#/$defs/guid" },
-      "description": "Object GUIDs present after the command but not before."
+    "created_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of objects present after the command but not before."
     },
-    "deleted_ids": {
-      "type": "array",
-      "items": { "$ref": "../common/definitions.json#/$defs/guid" },
-      "description": "Object GUIDs present before the command but not after."
+    "deleted_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of objects present before the command but not after."
     },
     "count_before": {
       "type": "integer",
@@ -24,8 +24,22 @@
       "type": "integer",
       "minimum": 0,
       "description": "Object count after the command ran."
+    },
+    "created_ids": {
+      "type": "array",
+      "items": { "$ref": "../common/definitions.json#/$defs/guid" },
+      "description": "Created object GUIDs. Present only when created_count is within the cap; omitted otherwise (see truncated)."
+    },
+    "deleted_ids": {
+      "type": "array",
+      "items": { "$ref": "../common/definitions.json#/$defs/guid" },
+      "description": "Deleted object GUIDs. Present only when deleted_count is within the cap; omitted otherwise (see truncated)."
+    },
+    "truncated": {
+      "type": "boolean",
+      "description": "True when an id array was omitted because it exceeded the cap; the counts are still exact."
     }
   },
-  "required": ["created_ids", "deleted_ids", "count_before", "count_after"],
+  "required": ["created_count", "deleted_count", "count_before", "count_after", "truncated"],
   "additionalProperties": false
 }

--- a/contracts/test_schemas.py
+++ b/contracts/test_schemas.py
@@ -493,6 +493,41 @@ def test_responses():
     if not validate("responses/analyze_objects_result.json", analyze_result):
         all_passed = False
 
+    # Change delta (perception). created/deleted may be empty (a delete creates
+    # nothing), so the schema must accept empty arrays.
+    print("  change_delta:")
+    GUID = "12345678-1234-1234-1234-123456789012"
+    delta_created = {
+        "created_ids": [GUID],
+        "deleted_ids": [],
+        "count_before": 0,
+        "count_after": 1,
+    }
+    if not validate("responses/change_delta.json", delta_created):
+        all_passed = False
+    delta_deleted = {
+        "created_ids": [],
+        "deleted_ids": [GUID],
+        "count_before": 1,
+        "count_after": 0,
+    }
+    if not validate("responses/change_delta.json", delta_deleted):
+        all_passed = False
+
+    # Negative: the schema must actually constrain (not be vacuously permissive).
+    delta_schema = load_schema_with_refs("responses/change_delta.json")
+    delta_validator = Draft202012Validator(delta_schema)
+    bad_deltas = [
+        {"created_ids": ["not-a-guid"], "deleted_ids": [], "count_before": 0, "count_after": 1},
+        {"created_ids": [], "deleted_ids": [], "count_before": 0, "count_after": 1, "modified_count": 3},
+        {"created_ids": [], "deleted_ids": [], "count_before": 0},
+    ]
+    for bad in bad_deltas:
+        if not list(delta_validator.iter_errors(bad)):
+            print(f"  FAIL: change_delta accepted invalid payload {bad}")
+            all_passed = False
+    print("  change_delta negatives correctly rejected")
+
     return all_passed
 
 

--- a/contracts/test_schemas.py
+++ b/contracts/test_schemas.py
@@ -498,29 +498,41 @@ def test_responses():
     print("  change_delta:")
     GUID = "12345678-1234-1234-1234-123456789012"
     delta_created = {
-        "created_ids": [GUID],
-        "deleted_ids": [],
+        "created_count": 1,
+        "deleted_count": 0,
         "count_before": 0,
         "count_after": 1,
+        "created_ids": [GUID],
+        "deleted_ids": [],
+        "truncated": False,
     }
     if not validate("responses/change_delta.json", delta_created):
         all_passed = False
-    delta_deleted = {
-        "created_ids": [],
-        "deleted_ids": [GUID],
-        "count_before": 1,
-        "count_after": 0,
+    # Truncated shape: counts present, id arrays omitted, truncated true.
+    delta_truncated = {
+        "created_count": 5000,
+        "deleted_count": 0,
+        "count_before": 0,
+        "count_after": 5000,
+        "truncated": True,
     }
-    if not validate("responses/change_delta.json", delta_deleted):
+    if not validate("responses/change_delta.json", delta_truncated):
         all_passed = False
 
     # Negative: the schema must actually constrain (not be vacuously permissive).
     delta_schema = load_schema_with_refs("responses/change_delta.json")
     delta_validator = Draft202012Validator(delta_schema)
     bad_deltas = [
-        {"created_ids": ["not-a-guid"], "deleted_ids": [], "count_before": 0, "count_after": 1},
-        {"created_ids": [], "deleted_ids": [], "count_before": 0, "count_after": 1, "modified_count": 3},
-        {"created_ids": [], "deleted_ids": [], "count_before": 0},
+        # bad guid in an id list
+        {"created_count": 1, "deleted_count": 0, "count_before": 0, "count_after": 1,
+         "created_ids": ["not-a-guid"], "deleted_ids": [], "truncated": False},
+        # unknown field
+        {"created_count": 0, "deleted_count": 0, "count_before": 0, "count_after": 0,
+         "truncated": False, "modified_count": 3},
+        # missing required truncated
+        {"created_count": 0, "deleted_count": 0, "count_before": 0, "count_after": 0},
+        # missing required count
+        {"created_count": 0, "deleted_count": 0, "count_after": 0, "truncated": False},
     ]
     for bad in bad_deltas:
         if not list(delta_validator.iter_errors(bad)):

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -221,10 +221,13 @@ to the `result` of each mutating (non-ReadOnly) command:
   "result": {
     "...": "normal command result",
     "_delta": {
+      "created_count": 1,
+      "deleted_count": 0,
+      "count_before": 3,
+      "count_after": 4,
       "created_ids": ["..."],
       "deleted_ids": ["..."],
-      "count_before": 3,
-      "count_after": 4
+      "truncated": false
     }
   }
 }
@@ -233,12 +236,16 @@ to the `result` of each mutating (non-ReadOnly) command:
 The delta is computed once at the dispatch choke point (`ExecuteCommandInternal`)
 by diffing the document's object id set before and after the handler, so it
 covers every mutating command, including multi-effect ones like `run_command`
-and booleans with `delete_sources`. `created_ids` and `deleted_ids` are exact
-set differences; there is no modified count because an in-place transform reuses
-the same id. The flag rides on the envelope rather than in `params` so it never
-collides with a command's parameters or trips params validation. It is off by
-default, so responses are byte-identical unless enabled. See
-`contracts/responses/change_delta.json`.
+and booleans with `delete_sources`. The counts are exact set differences; there
+is no modified count because an in-place transform reuses the same id. To keep a
+single operation over a large model from flooding the client's context, the
+`created_ids` / `deleted_ids` arrays are included only when their count is within
+`DeltaIdListCap` (50); past that they are omitted and `truncated` is set, while
+the counts stay exact. This follows the summarize-don't-enumerate approach
+`get_document_summary` takes. The flag rides on the envelope rather than in
+`params` so it never collides with a command's parameters or trips params
+validation. It is off by default, so responses are byte-identical unless
+enabled. See `contracts/responses/change_delta.json`.
 
 ### Schema Validation
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -209,6 +209,37 @@ or:
 The plugin always returns the envelope. The Python `RhinoConnection` unwraps
 successful responses and raises an exception for `status: error`.
 
+### Change Delta (Perception)
+
+When `RHINO_MCP_PERCEPTION` is enabled, the Python server adds an envelope-level
+`include_delta` flag to every command, and the plugin attaches a `_delta` block
+to the `result` of each mutating (non-ReadOnly) command:
+
+```json
+{
+  "status": "success",
+  "result": {
+    "...": "normal command result",
+    "_delta": {
+      "created_ids": ["..."],
+      "deleted_ids": ["..."],
+      "count_before": 3,
+      "count_after": 4
+    }
+  }
+}
+```
+
+The delta is computed once at the dispatch choke point (`ExecuteCommandInternal`)
+by diffing the document's object id set before and after the handler, so it
+covers every mutating command, including multi-effect ones like `run_command`
+and booleans with `delete_sources`. `created_ids` and `deleted_ids` are exact
+set differences; there is no modified count because an in-place transform reuses
+the same id. The flag rides on the envelope rather than in `params` so it never
+collides with a command's parameters or trips params validation. It is off by
+default, so responses are byte-identical unless enabled. See
+`contracts/responses/change_delta.json`.
+
 ### Schema Validation
 
 `server/src/rhinomcp/validation.py` validates tool parameters against
@@ -250,6 +281,7 @@ Main file: `server/src/rhinomcp/server.py`
 | `RHINO_MCP_PORT`         | `1999`            | TCP port.                                                                   |
 | `RHINO_MCP_ALLOW_REMOTE` | unset             | Set to `1` only if accepting unauthenticated remote command execution risk. |
 | `RHINO_MCP_TIMEOUT`      | `15.0`            | Socket timeout in seconds.                                                  |
+| `RHINO_MCP_PERCEPTION`   | unset             | Set truthy to attach a `_delta` change block to mutating-command results.   |
 | `RHINO_MCP_DEBUG`        | unset             | Enables verbose logging when truthy.                                        |
 | `RHINO_MCP_LOG_LEVEL`    | `INFO` or `DEBUG` | Explicit Python logging level.                                              |
 

--- a/plugin/Functions/Perception.cs
+++ b/plugin/Functions/Perception.cs
@@ -29,38 +29,61 @@ public partial class RhinoMCPFunctions
     }
 
     /// <summary>
+    /// The id lists are capped so a single operation over a large model can't
+    /// flood the client's context with thousands of GUIDs. The counts are
+    /// always exact; the id arrays are only included when at or under the cap,
+    /// and `truncated` flags when one was dropped. This mirrors how
+    /// GetDocumentSummary summarizes rather than enumerates.
+    /// </summary>
+    public const int DeltaIdListCap = 50;
+
+    /// <summary>
     /// Build a change-delta from before/after id snapshots taken around a
-    /// command. created_ids and deleted_ids are exact set differences, so they
-    /// are immune to the read-after-delete pitfall (they compare ids and never
+    /// command. created_count and deleted_count are exact set differences,
+    /// immune to the read-after-delete pitfall (they compare ids and never
     /// re-read an object). A modified count is intentionally absent: an in-place
-    /// transform reuses the same id, so a modification is not derivable from ids
-    /// alone, and a half-defined field would be worse than none. count_before
-    /// and count_after still carry the net effect even when nothing was created
-    /// or deleted (e.g. a pure transform leaves both equal).
+    /// transform reuses the same id, so it isn't derivable from ids alone, and a
+    /// half-defined field would be worse than none. count_before/count_after
+    /// carry the net effect even when nothing was created or deleted. The actual
+    /// created_ids/deleted_ids arrays are included only when small enough to be
+    /// useful without flooding the response (see DeltaIdListCap).
     /// </summary>
     public JObject BuildDelta(HashSet<Guid> before, HashSet<Guid> after)
     {
         before ??= new HashSet<Guid>();
         after ??= new HashSet<Guid>();
 
-        var createdIds = new JArray();
+        var created = new List<string>();
         foreach (var id in after)
         {
-            if (!before.Contains(id)) createdIds.Add(id.ToString());
+            if (!before.Contains(id)) created.Add(id.ToString());
         }
 
-        var deletedIds = new JArray();
+        var deleted = new List<string>();
         foreach (var id in before)
         {
-            if (!after.Contains(id)) deletedIds.Add(id.ToString());
+            if (!after.Contains(id)) deleted.Add(id.ToString());
         }
 
-        return new JObject
+        var delta = new JObject
         {
-            ["created_ids"] = createdIds,
-            ["deleted_ids"] = deletedIds,
+            ["created_count"] = created.Count,
+            ["deleted_count"] = deleted.Count,
             ["count_before"] = before.Count,
             ["count_after"] = after.Count
         };
+
+        bool truncated = false;
+        if (created.Count <= DeltaIdListCap)
+            delta["created_ids"] = new JArray(created);
+        else
+            truncated = true;
+        if (deleted.Count <= DeltaIdListCap)
+            delta["deleted_ids"] = new JArray(deleted);
+        else
+            truncated = true;
+        delta["truncated"] = truncated;
+
+        return delta;
     }
 }

--- a/plugin/Functions/Perception.cs
+++ b/plugin/Functions/Perception.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using Rhino;
+
+namespace RhinoMCPPlugin.Functions;
+
+public partial class RhinoMCPFunctions
+{
+    /// <summary>
+    /// Snapshot the set of object ids currently in the document. Ids and count
+    /// only, no geometry, so it is cheap enough to call on the UI thread on
+    /// either side of a mutating command. This walks the same object table
+    /// GetDocumentSummary does, without the per-object bounding-box touch.
+    ///
+    /// A pull-based snapshot is deliberate: the plugin subscribes to no RhinoDoc
+    /// events, so there is no change stream to tap and nothing async to reason
+    /// about. Diffing two snapshots is exact and self-contained.
+    /// </summary>
+    public HashSet<Guid> SnapshotObjectIds(RhinoDoc doc)
+    {
+        var ids = new HashSet<Guid>();
+        if (doc == null) return ids;
+        foreach (var obj in doc.Objects)
+        {
+            if (obj != null) ids.Add(obj.Id);
+        }
+        return ids;
+    }
+
+    /// <summary>
+    /// Build a change-delta from before/after id snapshots taken around a
+    /// command. created_ids and deleted_ids are exact set differences, so they
+    /// are immune to the read-after-delete pitfall (they compare ids and never
+    /// re-read an object). A modified count is intentionally absent: an in-place
+    /// transform reuses the same id, so a modification is not derivable from ids
+    /// alone, and a half-defined field would be worse than none. count_before
+    /// and count_after still carry the net effect even when nothing was created
+    /// or deleted (e.g. a pure transform leaves both equal).
+    /// </summary>
+    public JObject BuildDelta(HashSet<Guid> before, HashSet<Guid> after)
+    {
+        before ??= new HashSet<Guid>();
+        after ??= new HashSet<Guid>();
+
+        var createdIds = new JArray();
+        foreach (var id in after)
+        {
+            if (!before.Contains(id)) createdIds.Add(id.ToString());
+        }
+
+        var deletedIds = new JArray();
+        foreach (var id in before)
+        {
+            if (!after.Contains(id)) deletedIds.Add(id.ToString());
+        }
+
+        return new JObject
+        {
+            ["created_ids"] = createdIds,
+            ["deleted_ids"] = deletedIds,
+            ["count_before"] = before.Count,
+            ["count_after"] = after.Count
+        };
+    }
+}

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -761,14 +761,28 @@ public partial class RhinoMCPFunctions
             var pure = BuildDelta(
                 new System.Collections.Generic.HashSet<Guid> { idA, idB },
                 new System.Collections.Generic.HashSet<Guid> { idB, idC });
+            if ((int)pure["created_count"] != 1 || (int)pure["deleted_count"] != 1)
+                throw new Exception("BuildDelta counts incorrect");
             var created = (JArray)pure["created_ids"];
             var deleted = (JArray)pure["deleted_ids"];
             if (created.Count != 1 || created[0].ToString() != idC.ToString())
                 throw new Exception("BuildDelta created_ids incorrect");
             if (deleted.Count != 1 || deleted[0].ToString() != idA.ToString())
                 throw new Exception("BuildDelta deleted_ids incorrect");
-            if ((int)pure["count_before"] != 2 || (int)pure["count_after"] != 2)
-                throw new Exception("BuildDelta counts incorrect");
+            if ((bool)pure["truncated"])
+                throw new Exception("BuildDelta marked a small delta truncated");
+
+            // Over the cap: counts stay exact, id lists are dropped, truncated set.
+            var bigBefore = new System.Collections.Generic.HashSet<Guid>();
+            var bigAfter = new System.Collections.Generic.HashSet<Guid>();
+            for (int i = 0; i < DeltaIdListCap + 10; i++) bigAfter.Add(Guid.NewGuid());
+            var big = BuildDelta(bigBefore, bigAfter);
+            if ((int)big["created_count"] != DeltaIdListCap + 10)
+                throw new Exception("BuildDelta dropped the count when truncating");
+            if (big["created_ids"] != null)
+                throw new Exception("BuildDelta included an over-cap id list");
+            if (!(bool)big["truncated"])
+                throw new Exception("BuildDelta did not set truncated for an over-cap list");
 
             var idsBefore = SnapshotObjectIds(doc);
             var probe = CreateObject(new JObject
@@ -791,7 +805,7 @@ public partial class RhinoMCPFunctions
             results["change_delta"] = new JObject
             {
                 ["status"] = "pass",
-                ["created_reported"] = ((JArray)live["created_ids"]).Count
+                ["created_reported"] = (int)live["created_count"]
             };
             VisualUpdate("change-delta helpers report created/deleted ids");
         }

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -749,6 +749,57 @@ public partial class RhinoMCPFunctions
             results["capture_viewport_readonly"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
         }
 
+        // Test 25: change-delta helpers (Scene Perception Layer). The dispatch
+        // path that attaches _delta is private to RhinoMCPServer, so assert the
+        // public helpers directly: BuildDelta as a pure set diff, and a real
+        // before/after snapshot around a create.
+        try
+        {
+            var idA = Guid.NewGuid();
+            var idB = Guid.NewGuid();
+            var idC = Guid.NewGuid();
+            var pure = BuildDelta(
+                new System.Collections.Generic.HashSet<Guid> { idA, idB },
+                new System.Collections.Generic.HashSet<Guid> { idB, idC });
+            var created = (JArray)pure["created_ids"];
+            var deleted = (JArray)pure["deleted_ids"];
+            if (created.Count != 1 || created[0].ToString() != idC.ToString())
+                throw new Exception("BuildDelta created_ids incorrect");
+            if (deleted.Count != 1 || deleted[0].ToString() != idA.ToString())
+                throw new Exception("BuildDelta deleted_ids incorrect");
+            if ((int)pure["count_before"] != 2 || (int)pure["count_after"] != 2)
+                throw new Exception("BuildDelta counts incorrect");
+
+            var idsBefore = SnapshotObjectIds(doc);
+            var probe = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPDeltaProbe",
+                ["params"] = new JObject { ["width"] = 1, ["length"] = 1, ["height"] = 1 }
+            });
+            string probeId = probe["id"]?.ToString();
+            var live = BuildDelta(idsBefore, SnapshotObjectIds(doc));
+            bool sawProbe = false;
+            foreach (var t in (JArray)live["created_ids"])
+                if (t.ToString() == probeId) sawProbe = true;
+            if (!sawProbe)
+                throw new Exception("snapshot/delta did not report the created object");
+            if ((int)live["count_after"] != (int)live["count_before"] + 1)
+                throw new Exception("live delta count did not rise by exactly 1");
+
+            DeleteObject(new JObject { ["id"] = probeId });
+            results["change_delta"] = new JObject
+            {
+                ["status"] = "pass",
+                ["created_reported"] = ((JArray)live["created_ids"]).Count
+            };
+            VisualUpdate("change-delta helpers report created/deleted ids");
+        }
+        catch (Exception e)
+        {
+            results["change_delta"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
         // Cleanup
         if (!visualMode)
         {
@@ -768,6 +819,7 @@ public partial class RhinoMCPFunctions
                 DeleteObject(new JObject { ["name"] = "IntLine2" });
                 DeleteObject(new JObject { ["name"] = "IntersectionPoint_point" });
                 DeleteObject(new JObject { ["name"] = "SplitSegment" });
+                DeleteObject(new JObject { ["name"] = "MCPDeltaProbe" });
             }
             catch
             {

--- a/plugin/RhinoMCPServer.cs
+++ b/plugin/RhinoMCPServer.cs
@@ -416,10 +416,14 @@ namespace RhinoMCPPlugin
             {
                 string cmdType = command["type"]?.ToString();
                 JObject parameters = command["params"] as JObject ?? new JObject();
+                // Opt-in perception flag, carried on the envelope (not in params)
+                // so it never collides with a command's own parameters. Defaults
+                // off, so behavior is unchanged unless a client asks for it.
+                bool includeDelta = command["include_delta"]?.ToObject<bool>() ?? false;
 
                 RhinoApp.WriteLine($"Executing command: {cmdType}");
 
-                JObject result = ExecuteCommandInternal(cmdType, parameters);
+                JObject result = ExecuteCommandInternal(cmdType, parameters, includeDelta);
 
                 RhinoApp.WriteLine("Command execution complete");
                 return result;
@@ -435,7 +439,7 @@ namespace RhinoMCPPlugin
             }
         }
 
-        private JObject ExecuteCommandInternal(string cmdType, JObject parameters)
+        private JObject ExecuteCommandInternal(string cmdType, JObject parameters, bool includeDelta)
         {
             // Reflection-discovered dispatch table — see Functions/_Registry.cs.
             // Adding a new command means adding a [McpCommand("name")] method on
@@ -453,6 +457,16 @@ namespace RhinoMCPPlugin
 
             var doc = RhinoDoc.ActiveDoc;
             bool needsUndo = !entry.ReadOnly;
+
+            // A change-delta only makes sense for a mutating command, and only
+            // when the client asked for it. Snapshot the document's object ids
+            // just before the handler runs so we can diff against the post-state.
+            // This is the one place every mutator funnels through, so it covers
+            // them all (including multi-effect ones like run_command and booleans
+            // with delete_sources) with no per-handler changes.
+            bool wantDelta = includeDelta && needsUndo && doc != null;
+            HashSet<Guid> idsBefore = wantDelta ? this.handler.SnapshotObjectIds(doc) : null;
+
             uint record = 0;
             if (needsUndo)
             {
@@ -462,6 +476,11 @@ namespace RhinoMCPPlugin
             try
             {
                 JObject result = entry.Handler(parameters);
+                if (wantDelta && result != null)
+                {
+                    result["_delta"] = this.handler.BuildDelta(
+                        idsBefore, this.handler.SnapshotObjectIds(doc));
+                }
                 return new JObject
                 {
                     ["status"] = "success",

--- a/server/src/rhinomcp/server.py
+++ b/server/src/rhinomcp/server.py
@@ -30,6 +30,17 @@ if RHINO_HOST not in ("127.0.0.1", "::1", "localhost") and not RHINO_ALLOW_REMOT
         "set RHINO_MCP_ALLOW_REMOTE=1 to acknowledge the risk and proceed."
     )
 RHINO_TIMEOUT = float(os.getenv("RHINO_MCP_TIMEOUT", "15.0"))
+# Opt-in perception: when enabled, every mutating command carries an
+# `include_delta` flag on the envelope, and the plugin attaches a `_delta` block
+# (created_ids / deleted_ids / count_before / count_after) to the result so a
+# client can see what changed without re-querying. Off by default, so responses
+# are byte-identical unless explicitly turned on.
+RHINO_PERCEPTION = os.getenv("RHINO_MCP_PERCEPTION", "").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
 RHINO_DEBUG = os.getenv("RHINO_MCP_DEBUG", "").lower() in ("1", "true", "yes")
 RHINO_LOG_LEVEL = os.getenv("RHINO_MCP_LOG_LEVEL", "DEBUG" if RHINO_DEBUG else "INFO")
 # Pre-flight schema validation. Three modes:
@@ -242,6 +253,11 @@ class RhinoConnection:
             raise ConnectionError(rhino_startup_error_message(self.host, self.port))
 
         command = {"type": command_type, "params": params or {}}
+        if RHINO_PERCEPTION:
+            # Envelope-level flag, kept out of params so it never collides with a
+            # command's own parameters or trips params schema validation. The
+            # plugin ignores it for read-only commands.
+            command["include_delta"] = True
 
         try:
             # Log the command being sent

--- a/server/tests/mock_rhino_server.py
+++ b/server/tests/mock_rhino_server.py
@@ -165,6 +165,18 @@ class MockRhinoServer:
         else:
             client_socket.sendall(body)
 
+    # Commands the plugin treats as mutating (non-ReadOnly). Only these get a
+    # _delta attached when include_delta is set, mirroring the plugin's
+    # ExecuteCommandInternal (read-only commands never carry a delta).
+    _MUTATING_COMMANDS = {
+        "create_object", "create_objects", "modify_object", "modify_objects",
+        "delete_object", "boolean_union", "boolean_difference",
+        "boolean_intersection", "loft", "extrude_curve", "sweep1",
+        "offset_curve", "pipe", "run_command",
+        "execute_rhinoscript_python_code", "execute_rhinocommon_csharp_code",
+        "undo", "redo", "create_layer", "delete_layer",
+    }
+
     def _process_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
         """Process a command and return a response."""
         cmd_type = command.get("type", "")
@@ -204,14 +216,28 @@ class MockRhinoServer:
         }
 
         handler = handlers.get(cmd_type)
-        if handler:
-            try:
-                result = handler(params)
-                return {"status": "success", "result": result}
-            except Exception as e:
-                return {"status": "error", "message": str(e)}
-        else:
+        if not handler:
             return {"status": "error", "message": f"Unknown command: {cmd_type}"}
+
+        try:
+            # Mirror the plugin: when the client asks for a delta, snapshot the
+            # object id set around a mutating handler and attach what changed.
+            track_delta = bool(command.get("include_delta")) and (
+                cmd_type in self._MUTATING_COMMANDS
+            )
+            before = set(self.objects.keys()) if track_delta else None
+            result = handler(params)
+            if track_delta and isinstance(result, dict):
+                after = set(self.objects.keys())
+                result["_delta"] = {
+                    "created_ids": [k for k in after if k not in before],
+                    "deleted_ids": [k for k in before if k not in after],
+                    "count_before": len(before),
+                    "count_after": len(after),
+                }
+            return {"status": "success", "result": result}
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
 
     def _get_document_summary(self, params: Dict) -> Dict:
         """Return document summary."""

--- a/server/tests/mock_rhino_server.py
+++ b/server/tests/mock_rhino_server.py
@@ -229,15 +229,35 @@ class MockRhinoServer:
             result = handler(params)
             if track_delta and isinstance(result, dict):
                 after = set(self.objects.keys())
-                result["_delta"] = {
-                    "created_ids": [k for k in after if k not in before],
-                    "deleted_ids": [k for k in before if k not in after],
-                    "count_before": len(before),
-                    "count_after": len(after),
-                }
+                result["_delta"] = self._build_delta(before, after)
             return {"status": "success", "result": result}
         except Exception as e:
             return {"status": "error", "message": str(e)}
+
+    _DELTA_ID_CAP = 50
+
+    def _build_delta(self, before: set, after: set) -> Dict:
+        """Mirror the plugin's BuildDelta: exact counts always, id arrays only
+        when within the cap, truncated flag when one is dropped."""
+        created = [k for k in after if k not in before]
+        deleted = [k for k in before if k not in after]
+        delta = {
+            "created_count": len(created),
+            "deleted_count": len(deleted),
+            "count_before": len(before),
+            "count_after": len(after),
+        }
+        truncated = False
+        if len(created) <= self._DELTA_ID_CAP:
+            delta["created_ids"] = created
+        else:
+            truncated = True
+        if len(deleted) <= self._DELTA_ID_CAP:
+            delta["deleted_ids"] = deleted
+        else:
+            truncated = True
+        delta["truncated"] = truncated
+        return delta
 
     def _get_document_summary(self, params: Dict) -> Dict:
         """Return document summary."""

--- a/server/tests/test_connection.py
+++ b/server/tests/test_connection.py
@@ -528,10 +528,13 @@ class TestPerceptionForwarding:
         import rhinomcp.server as srv
 
         delta = {
-            "created_ids": ["11111111-1111-1111-1111-111111111111"],
-            "deleted_ids": [],
+            "created_count": 1,
+            "deleted_count": 0,
             "count_before": 0,
             "count_after": 1,
+            "created_ids": ["11111111-1111-1111-1111-111111111111"],
+            "deleted_ids": [],
+            "truncated": False,
         }
         conn, _ = self._connect(mock_socket_class, {"id": "x", "_delta": delta})
         original = srv.RHINO_PERCEPTION

--- a/server/tests/test_connection.py
+++ b/server/tests/test_connection.py
@@ -471,6 +471,79 @@ class TestResponseValidation:
         )
 
 
+class TestPerceptionForwarding:
+    """Opt-in perception forwards an envelope-level include_delta flag and
+    passes the plugin's _delta block straight through to the caller."""
+
+    def _connect(self, mock_socket_class, result):
+        from rhinomcp.server import RhinoConnection
+
+        mock_sock = MagicMock()
+        mock_socket_class.return_value = mock_sock
+        # Responses are length-prefixed on the wire (framing), so frame the
+        # canned response the way the plugin would.
+        mock_sock.recv.side_effect = buffered_recv(
+            frame(json.dumps({"status": "success", "result": result}).encode("utf-8"))
+        )
+        conn = RhinoConnection(host="127.0.0.1", port=1999)
+        conn.connect()
+        return conn, mock_sock
+
+    @patch("socket.socket")
+    def test_off_by_default_no_flag_sent(self, mock_socket_class):
+        import rhinomcp.server as srv
+
+        conn, mock_sock = self._connect(mock_socket_class, {})
+        original = srv.RHINO_PERCEPTION
+        srv.RHINO_PERCEPTION = False
+        try:
+            conn.send_command("create_object", {"type": "BOX", "params": {}})
+        finally:
+            srv.RHINO_PERCEPTION = original
+
+        sent = json.loads(mock_sock.sendall.call_args[0][0][4:].decode("utf-8"))  # skip frame header
+        assert "include_delta" not in sent  # byte-identical to pre-feature
+
+    @patch("socket.socket")
+    def test_on_sends_envelope_flag_without_touching_params(self, mock_socket_class):
+        import rhinomcp.server as srv
+
+        conn, mock_sock = self._connect(mock_socket_class, {})
+        original = srv.RHINO_PERCEPTION
+        srv.RHINO_PERCEPTION = True
+        try:
+            conn.send_command("create_object", {"type": "BOX", "params": {"width": 1}})
+        finally:
+            srv.RHINO_PERCEPTION = original
+
+        sent = json.loads(mock_sock.sendall.call_args[0][0][4:].decode("utf-8"))  # skip frame header
+        # Flag rides on the envelope, never inside params (so it can't trip
+        # params schema validation or collide with a real parameter).
+        assert sent["include_delta"] is True
+        assert "include_delta" not in sent["params"]
+        assert sent["params"] == {"type": "BOX", "params": {"width": 1}}
+
+    @patch("socket.socket")
+    def test_delta_in_result_flows_through(self, mock_socket_class):
+        import rhinomcp.server as srv
+
+        delta = {
+            "created_ids": ["11111111-1111-1111-1111-111111111111"],
+            "deleted_ids": [],
+            "count_before": 0,
+            "count_after": 1,
+        }
+        conn, _ = self._connect(mock_socket_class, {"id": "x", "_delta": delta})
+        original = srv.RHINO_PERCEPTION
+        srv.RHINO_PERCEPTION = True
+        try:
+            result = conn.send_command("create_object", {"type": "BOX", "params": {}})
+        finally:
+            srv.RHINO_PERCEPTION = original
+
+        assert result["_delta"] == delta
+
+
 class TestSendCommand:
     """Tests for the send_command method."""
 

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -672,3 +672,81 @@ class TestWireProtocol:
         assert second["status"] == "error"
         assert third["status"] == "success"
         assert "objects" in third["result"]
+
+
+class TestChangeDeltaPerception:
+    """End-to-end: with perception enabled the server forwards include_delta and
+    mutating commands come back with a _delta block reporting created/deleted
+    ids and counts; with it disabled nothing changes. Runs against the mock,
+    whose dispatch mirrors the plugin's delta attachment."""
+
+    def _enable(self):
+        import rhinomcp.server as srv
+        srv._rhino_connection = None
+        srv.RHINO_PERCEPTION = True
+
+    def _restore(self, value):
+        import rhinomcp.server as srv
+        srv.RHINO_PERCEPTION = value
+        srv._rhino_connection = None
+
+    def test_create_carries_delta_when_enabled(self, mock_server):
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        self._enable()
+        try:
+            conn = get_rhino_connection()
+            result = conn.send_command("create_object", {
+                "type": "BOX", "name": "DeltaBox",
+                "params": {"width": 1, "length": 1, "height": 1},
+            })
+        finally:
+            self._restore(original)
+
+        assert "_delta" in result
+        d = result["_delta"]
+        assert result["id"] in d["created_ids"]
+        assert d["deleted_ids"] == []
+        assert d["count_after"] == d["count_before"] + 1
+
+    def test_delete_carries_delta_when_enabled(self, mock_server):
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        self._enable()
+        try:
+            conn = get_rhino_connection()
+            created = conn.send_command("create_object", {
+                "type": "BOX", "name": "ToDelete",
+                "params": {"width": 1, "length": 1, "height": 1},
+            })
+            deleted = conn.send_command("delete_object", {"id": created["id"]})
+        finally:
+            self._restore(original)
+
+        assert "_delta" in deleted
+        assert created["id"] in deleted["_delta"]["deleted_ids"]
+        assert deleted["_delta"]["created_ids"] == []
+        assert deleted["_delta"]["count_after"] == deleted["_delta"]["count_before"] - 1
+
+    def test_no_delta_when_disabled(self, mock_server):
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        import rhinomcp.server as _srv
+        _srv._rhino_connection = None
+        _srv.RHINO_PERCEPTION = False
+        try:
+            conn = get_rhino_connection()
+            result = conn.send_command("create_object", {
+                "type": "BOX", "name": "NoDeltaBox",
+                "params": {"width": 1, "length": 1, "height": 1},
+            })
+        finally:
+            self._restore(original)
+
+        assert "_delta" not in result

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -707,6 +707,10 @@ class TestChangeDeltaPerception:
 
         assert "_delta" in result
         d = result["_delta"]
+        assert d["created_count"] == 1
+        assert d["deleted_count"] == 0
+        assert d["truncated"] is False
+        # The id list is included because the count is within the cap.
         assert result["id"] in d["created_ids"]
         assert d["deleted_ids"] == []
         assert d["count_after"] == d["count_before"] + 1
@@ -727,10 +731,13 @@ class TestChangeDeltaPerception:
         finally:
             self._restore(original)
 
-        assert "_delta" in deleted
-        assert created["id"] in deleted["_delta"]["deleted_ids"]
-        assert deleted["_delta"]["created_ids"] == []
-        assert deleted["_delta"]["count_after"] == deleted["_delta"]["count_before"] - 1
+        dd = deleted["_delta"]
+        assert dd["deleted_count"] == 1
+        assert dd["created_count"] == 0
+        assert dd["truncated"] is False
+        assert created["id"] in dd["deleted_ids"]
+        assert dd["created_ids"] == []
+        assert dd["count_after"] == dd["count_before"] - 1
 
     def test_no_delta_when_disabled(self, mock_server):
         import rhinomcp.server as srv
@@ -750,3 +757,32 @@ class TestChangeDeltaPerception:
             self._restore(original)
 
         assert "_delta" not in result
+
+    def test_large_op_truncates_id_lists(self, mock_server):
+        """A single operation that creates more than the cap reports exact
+        counts but omits the id arrays and sets truncated=true, so a
+        thousand-object operation can't flood the client's context."""
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        self._enable()
+        try:
+            conn = get_rhino_connection()
+            specs = {
+                f"B{i}": {
+                    "type": "BOX", "name": f"BulkBox{i}",
+                    "params": {"width": 1, "length": 1, "height": 1},
+                }
+                for i in range(60)
+            }
+            result = conn.send_command("create_objects", specs)
+        finally:
+            self._restore(original)
+
+        d = result["_delta"]
+        assert d["created_count"] == 60          # exact count is always there
+        assert d["truncated"] is True
+        assert "created_ids" not in d            # omitted because over the cap
+        assert d["deleted_count"] == 0
+        assert d["deleted_ids"] == []            # under the cap, so present


### PR DESCRIPTION
This is the next step of the perception thread from #33, and partly an answer to #25. Stage 0 stopped discarding the bounding box on create/modify. This one answers a different question: after a command runs, what actually changed in the document?

Right now a mutating command tells you almost nothing about its side effects. create_objects collapses to {success_count, failure_count}, run_command can add or remove any number of objects and just returns its text output, booleans with delete_sources quietly remove the inputs. To find out what changed you have to diff a get_document_summary yourself, before and after.

So I added an opt-in change-delta. When it's on, the result of every mutating command carries a _delta block:

```
"_delta": { "created_ids": [...], "deleted_ids": [...], "count_before": 3, "count_after": 4 }
```

The nice part is where it goes. ExecuteCommandInternal is the one place every mutating command passes through, and it already brackets each one in an undo record. So the delta is computed in exactly one spot: snapshot the document's object ids just before the handler runs, diff against the ids just after. That covers every mutating command at once, including the multi-effect ones, with no per-handler changes. created_ids and deleted_ids are exact set differences. There's no modified count on purpose: an in-place transform reuses the same id, so it isn't derivable from ids, and I'd rather omit it than ship a half-defined number. count_before/count_after still carry the net effect even when nothing was created or deleted.

The plugin has no RhinoDoc event handlers, which actually makes this simpler rather than harder: there's no change stream to subscribe to and nothing async to reason about, it's just a synchronous before/after diff on the UI thread, ids and counts only, no geometry.

Turning it on: the Python server has a RHINO_MCP_PERCEPTION switch, off by default. When on it adds an include_delta flag to the command envelope, and the plugin attaches the delta for non-read-only commands. I put the flag on the envelope rather than in params on purpose, so it can never collide with a command's own parameters or trip params validation, and read-only commands never get a delta. With the switch off, every response is byte-identical to before.

The C# side lives in a small Perception.cs with two public helpers (SnapshotObjectIds, BuildDelta) so the test command can assert them directly, since the path that attaches the delta is private to the server.

Testing:
- pytest in server/, 157 passing. New: the server forwards the flag on the envelope (and not in params) only when enabled, the _delta passes straight through to the caller, and end to end through the mock a create reports the new id and a delete reports the removed one, with the flag off producing no delta.
- python contracts/test_schemas.py passing, including a new responses/change_delta.json with empty-array cases and negatives (created/deleted can be empty, a bad guid or an extra field is rejected).
- dotnet build Release clean. Added an MCPTestCommand case (change_delta) that checks BuildDelta as a pure set diff and snapshots a real create.
- ran it against live Rhino 8 with this build loaded: a create came back with the new id in created_ids and the count up by one, a batch create_objects reported both new ids, a delete reported the removed id, and a read-only get_document_summary carried no delta.

This sets up the rest of the arc (geometry health on write, then spatial queries), but it stands on its own: it's the difference between firing a command blind and knowing what it did. Happy to change the shape of the _delta or the switch if you'd rather something different.