### PR TITLE
Add a measure_objects command for clash and bounding-box gap

### DIFF
--- a/contracts/commands/measure_objects.json
+++ b/contracts/commands/measure_objects.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "measure_objects.json",
+  "title": "MeasureObjects Command",
+  "description": "Report the spatial relationship (clash and bounding-box gap) between exactly two objects. Read-only.",
+  "type": "object",
+  "properties": {
+    "object_ids": {
+      "type": "array",
+      "items": { "$ref": "../common/definitions.json#/$defs/guid" },
+      "minItems": 2,
+      "maxItems": 2,
+      "description": "Exactly two object GUIDs to measure between."
+    }
+  },
+  "required": ["object_ids"],
+  "additionalProperties": false
+}

--- a/contracts/protocol.json
+++ b/contracts/protocol.json
@@ -22,6 +22,7 @@
             "get_object_attributes",
             "update_object_attributes",
             "analyze_objects",
+            "measure_objects",
             "get_selected_objects_info",
             "get_document_summary",
             "get_objects",

--- a/contracts/responses/measure_result.json
+++ b/contracts/responses/measure_result.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "measure_result.json",
+  "title": "MeasureObjects Result",
+  "description": "Spatial relationship between two objects.",
+  "type": "object",
+  "properties": {
+    "object_a": { "$ref": "../common/definitions.json#/$defs/guid" },
+    "object_b": { "$ref": "../common/definitions.json#/$defs/guid" },
+    "clash": {
+      "type": "boolean",
+      "description": "Whether the two objects intersect."
+    },
+    "intersection_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Intersection curves+points (brep) or events (curve); 0 for the bbox method."
+    },
+    "bbox_gap": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Exact minimum distance between the two bounding boxes (0 if they meet or overlap); a lower bound on the true distance."
+    },
+    "method": {
+      "type": "string",
+      "enum": ["brep", "curve", "bbox"],
+      "description": "How clash was determined."
+    }
+  },
+  "required": ["object_a", "object_b", "clash", "intersection_count", "bbox_gap", "method"],
+  "additionalProperties": false
+}

--- a/contracts/test_schemas.py
+++ b/contracts/test_schemas.py
@@ -240,6 +240,7 @@ def test_new_commands():
         ("commands/analyze_objects.json", {"id": GUID}),
         ("commands/analyze_objects.json", {"object_ids": [GUID]}),
         ("commands/analyze_objects.json", {"selected": True}),
+        ("commands/measure_objects.json", {"object_ids": [GUID, GUID]}),
         ("commands/gh_create_document.json", {"new_if_missing": True, "make_active": True, "open_canvas": True}),
         ("commands/gh_get_document_info.json", {}),
         ("commands/gh_search_components.json", {"query": "addition", "limit": 10}),
@@ -553,6 +554,33 @@ def test_responses():
             all_passed = False
     print("  change_delta negatives correctly rejected")
 
+    # Measure result
+    print("  measure_result:")
+    measure_result = {
+        "object_a": GUID,
+        "object_b": GUID,
+        "clash": False,
+        "intersection_count": 0,
+        "bbox_gap": 3.5,
+        "method": "brep",
+    }
+    if not validate("responses/measure_result.json", measure_result):
+        all_passed = False
+    # Negative: an unknown method and a missing field must be rejected.
+    measure_schema = load_schema_with_refs("responses/measure_result.json")
+    measure_validator = Draft202012Validator(measure_schema)
+    bad_measures = [
+        {"object_a": GUID, "object_b": GUID, "clash": False,
+         "intersection_count": 0, "bbox_gap": 1.0, "method": "voxel"},
+        {"object_a": GUID, "object_b": GUID, "clash": False,
+         "intersection_count": 0, "method": "brep"},
+    ]
+    for bad in bad_measures:
+        if not list(measure_validator.iter_errors(bad)):
+            print(f"  FAIL: measure_result accepted invalid payload {bad}")
+            all_passed = False
+    print("  measure_result negatives correctly rejected")
+
     return all_passed
 
 
@@ -604,6 +632,10 @@ def test_invalid_examples():
         ("commands/analyze_objects.json", {"object_ids": []}, "analyze_objects empty object_ids"),
         ("commands/analyze_objects.json", {"id": "12345678-1234-1234-1234-123456789012", "selected": True}, "analyze_objects mixed selectors"),
         ("commands/analyze_objects.json", {"selected": False}, "analyze_objects selected=false"),
+        ("commands/measure_objects.json", {"object_ids": ["12345678-1234-1234-1234-123456789012"]}, "measure_objects needs two ids"),
+        ("commands/measure_objects.json", {"object_ids": ["12345678-1234-1234-1234-123456789012", "12345678-1234-1234-1234-123456789012", "12345678-1234-1234-1234-123456789012"]}, "measure_objects too many ids"),
+        ("commands/measure_objects.json", {"object_ids": ["not-a-guid", "12345678-1234-1234-1234-123456789012"]}, "measure_objects bad guid"),
+        ("commands/measure_objects.json", {"object_ids": ["12345678-1234-1234-1234-123456789012", "12345678-1234-1234-1234-123456789012"], "bogus": 1}, "measure_objects unknown field"),
         ("commands/gh_create_document.json", {"template_path": "example.gh"}, "gh_create_document unknown field"),
         ("commands/gh_batch_search_components.json", {"queries": []}, "gh_batch_search_components empty queries"),
         ("commands/gh_get_component_type_info.json", {}, "gh_get_component_type_info missing selector"),
@@ -786,7 +818,7 @@ def test_protocol_envelope():
         "create_object", "create_objects", "modify_object", "modify_objects",
         "delete_object", "get_object_info", "get_selected_objects_info",
         "get_object_attributes", "update_object_attributes",
-        "analyze_objects",
+        "analyze_objects", "measure_objects",
         "get_document_summary", "get_objects", "select_objects",
         "create_layer", "delete_layer", "get_or_set_current_layer",
         "execute_rhinoscript_python_code", "execute_rhinocommon_csharp_code",

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -384,7 +384,7 @@ commands and 25 Grasshopper commands.
 | Area                          | Commands                                                                                                                                              |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Object creation and edits     | `create_object`, `create_objects`, `modify_object`, `modify_objects`, `delete_object`                                                                 |
-| Object and document query     | `get_document_summary`, `get_objects`, `get_object_info`, `get_selected_objects_info`, `get_object_attributes`, `analyze_objects`, `capture_viewport` |
+| Object and document query     | `get_document_summary`, `get_objects`, `get_object_info`, `get_selected_objects_info`, `get_object_attributes`, `analyze_objects`, `measure_objects`, `capture_viewport` |
 | Object attributes             | `update_object_attributes`                                                                                                                            |
 | Selection                     | `select_objects`                                                                                                                                      |
 | Layers                        | `create_layer`, `delete_layer`, `get_or_set_current_layer`                                                                                            |

--- a/plugin/Functions/MeasureObjects.cs
+++ b/plugin/Functions/MeasureObjects.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using Rhino;
+using Rhino.DocObjects;
+using Rhino.Geometry;
+
+namespace RhinoMCPPlugin.Functions;
+
+public partial class RhinoMCPFunctions
+{
+    /// <summary>
+    /// Reports the spatial relationship between two objects: whether they clash
+    /// (intersect) and the gap between their bounding boxes. Read-only.
+    ///
+    /// clash is exact for the cases RhinoCommon gives an exact pairwise
+    /// intersection for (brep/brep, curve/curve), and for two closed solids it
+    /// also reports a clash when one is fully contained in the other (their
+    /// surfaces never cross in that case); for anything else it falls
+    /// back to bounding-box overlap, and the `method` field always says which
+    /// was used so the caller knows how precise the answer is. bbox_gap is the
+    /// exact minimum distance between the two axis-aligned bounding boxes (0 if
+    /// they meet or overlap), which is a conservative lower bound on the true
+    /// surface-to-surface distance. It is emitted as a raw number, not through
+    /// the point serializer, so it is not rounded.
+    /// </summary>
+    [McpCommand("measure_objects", ReadOnly = true)]
+    public JObject MeasureObjects(JObject parameters)
+    {
+        var doc = RhinoDoc.ActiveDoc;
+        var ids = parameters["object_ids"]?.ToObject<List<string>>() ?? new List<string>();
+        if (ids.Count != 2)
+            throw new ArgumentException("measure_objects requires object_ids with exactly two object ids.");
+
+        var objA = getObjectByIdOrName(new JObject { ["id"] = ids[0] });
+        var objB = getObjectByIdOrName(new JObject { ["id"] = ids[1] });
+
+        var geoA = objA.Geometry;
+        var geoB = objB.Geometry;
+        double tol = doc.ModelAbsoluteTolerance;
+
+        var bboxA = geoA.GetBoundingBox(true);
+        var bboxB = geoB.GetBoundingBox(true);
+        double bboxGap = BoundingBoxGap(bboxA, bboxB);
+
+        var brepA = TryGetBrep(geoA);
+        var brepB = TryGetBrep(geoB);
+        var curveA = geoA as Curve;
+        var curveB = geoB as Curve;
+
+        bool clash;
+        int intersectionCount;
+        string method;
+
+        if (brepA != null && brepB != null)
+        {
+            Rhino.Geometry.Intersect.Intersection.BrepBrep(
+                brepA, brepB, tol, out Curve[] curves, out Point3d[] points);
+            int nc = curves?.Length ?? 0;
+            int np = points?.Length ?? 0;
+            intersectionCount = nc + np;
+            clash = intersectionCount > 0;
+            // Surfaces that don't cross can still clash when one solid sits fully
+            // inside the other: their surfaces never intersect in that case. For
+            // two closed solids, fall back to a containment test.
+            if (!clash && brepA.IsSolid && brepB.IsSolid)
+                clash = BrepContains(brepA, brepB, tol) || BrepContains(brepB, brepA, tol);
+            method = "brep";
+        }
+        else if (curveA != null && curveB != null)
+        {
+            var events = Rhino.Geometry.Intersect.Intersection.CurveCurve(curveA, curveB, tol, tol);
+            intersectionCount = events?.Count ?? 0;
+            clash = intersectionCount > 0;
+            method = "curve";
+        }
+        else
+        {
+            // No exact pairwise intersection available for this pair (points,
+            // meshes, or mixed curve/brep): report bounding-box overlap, and
+            // say so via method so the caller doesn't read it as exact.
+            clash = bboxGap <= tol;
+            intersectionCount = 0;
+            method = "bbox";
+        }
+
+        return new JObject
+        {
+            ["object_a"] = objA.Id.ToString(),
+            ["object_b"] = objB.Id.ToString(),
+            ["clash"] = clash,
+            ["intersection_count"] = intersectionCount,
+            ["bbox_gap"] = bboxGap,
+            ["method"] = method
+        };
+    }
+
+    /// <summary>Brep for the geometry where one is available, else null.</summary>
+    private Brep TryGetBrep(GeometryBase geometry)
+    {
+        if (geometry is Brep brep) return brep;
+        if (geometry is Extrusion extrusion) return extrusion.ToBrep();
+        if (geometry is Surface surface) return surface.ToBrep();
+        return null;
+    }
+
+    /// <summary>
+    /// True when the closed solid <paramref name="outer"/> contains
+    /// <paramref name="inner"/>. Tests a vertex of inner, which lies on inner's
+    /// surface; if that point is inside outer and the two surfaces do not cross,
+    /// inner sits entirely within outer. Caller guards that both breps are solid,
+    /// which IsPointInside requires.
+    /// </summary>
+    private bool BrepContains(Brep outer, Brep inner, double tol)
+    {
+        var vertices = inner.Vertices;
+        if (vertices == null || vertices.Count == 0) return false;
+        return outer.IsPointInside(vertices[0].Location, tol, false);
+    }
+
+    /// <summary>
+    /// Exact minimum Euclidean distance between two axis-aligned bounding boxes,
+    /// 0 when they meet or overlap. Per axis the gap is the positive separation
+    /// (or 0 if they overlap on that axis); the total is their root-sum-square.
+    /// </summary>
+    private double BoundingBoxGap(BoundingBox a, BoundingBox b)
+    {
+        double gx = Math.Max(0, Math.Max(a.Min.X - b.Max.X, b.Min.X - a.Max.X));
+        double gy = Math.Max(0, Math.Max(a.Min.Y - b.Max.Y, b.Min.Y - a.Max.Y));
+        double gz = Math.Max(0, Math.Max(a.Min.Z - b.Max.Z, b.Min.Z - a.Max.Z));
+        return Math.Sqrt(gx * gx + gy * gy + gz * gz);
+    }
+}

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -871,6 +871,81 @@ public partial class RhinoMCPFunctions
             results["layer_name_live"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
         }
 
+        // Test: measure_objects reports clash and bounding-box gap. Two 2x2x2
+        // boxes 10 apart on X must not clash (positive gap, brep method); a box
+        // overlapping the first must clash with a zero gap.
+        try
+        {
+            var mA = CreateObject(new JObject
+            {
+                ["type"] = "BOX", ["name"] = "MCPMeasureA",
+                ["params"] = new JObject { ["width"] = 2, ["length"] = 2, ["height"] = 2 }
+            });
+            var mB = CreateObject(new JObject
+            {
+                ["type"] = "BOX", ["name"] = "MCPMeasureB",
+                ["params"] = new JObject { ["width"] = 2, ["length"] = 2, ["height"] = 2 },
+                ["translation"] = new JArray { 10, 0, 0 }
+            });
+            var mC = CreateObject(new JObject
+            {
+                ["type"] = "BOX", ["name"] = "MCPMeasureC",
+                ["params"] = new JObject { ["width"] = 2, ["length"] = 2, ["height"] = 2 },
+                ["translation"] = new JArray { 1, 0, 0 }
+            });
+            string mAId = mA["id"]?.ToString();
+            string mBId = mB["id"]?.ToString();
+            string mCId = mC["id"]?.ToString();
+
+            var apart = MeasureObjects(new JObject { ["object_ids"] = new JArray { mAId, mBId } });
+            if (apart["clash"].ToObject<bool>())
+                throw new Exception("measure_objects reported a clash for boxes 10 apart");
+            if (apart["method"]?.ToString() != "brep")
+                throw new Exception("measure_objects expected brep method, got " + apart["method"]);
+            if (apart["bbox_gap"].ToObject<double>() <= 0)
+                throw new Exception("measure_objects expected a positive bbox_gap for separated boxes");
+
+            var overlap = MeasureObjects(new JObject { ["object_ids"] = new JArray { mAId, mCId } });
+            if (!overlap["clash"].ToObject<bool>())
+                throw new Exception("measure_objects missed a clash for overlapping boxes");
+            if (overlap["bbox_gap"].ToObject<double>() != 0.0)
+                throw new Exception("measure_objects expected a zero bbox_gap for overlapping boxes");
+
+            // A small box fully inside a large box clashes even though their
+            // surfaces never cross (containment).
+            var mBig = CreateObject(new JObject
+            {
+                ["type"] = "BOX", ["name"] = "MCPMeasureBig",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 }
+            });
+            var mSmall = CreateObject(new JObject
+            {
+                ["type"] = "BOX", ["name"] = "MCPMeasureSmall",
+                ["params"] = new JObject { ["width"] = 2, ["length"] = 2, ["height"] = 2 }
+            });
+            string mBigId = mBig["id"]?.ToString();
+            string mSmallId = mSmall["id"]?.ToString();
+            var contained = MeasureObjects(new JObject { ["object_ids"] = new JArray { mBigId, mSmallId } });
+            DeleteObject(new JObject { ["id"] = mBigId });
+            DeleteObject(new JObject { ["id"] = mSmallId });
+            if (!contained["clash"].ToObject<bool>())
+                throw new Exception("measure_objects missed containment (small box fully inside big box)");
+
+            DeleteObject(new JObject { ["id"] = mAId });
+            DeleteObject(new JObject { ["id"] = mBId });
+            DeleteObject(new JObject { ["id"] = mCId });
+            results["measure_objects"] = new JObject
+            {
+                ["status"] = "pass",
+                ["gap_apart"] = apart["bbox_gap"]
+            };
+            VisualUpdate("measure_objects clash + bbox gap");
+        }
+        catch (Exception e)
+        {
+            results["measure_objects"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
         // Cleanup
         if (!visualMode)
         {
@@ -891,6 +966,11 @@ public partial class RhinoMCPFunctions
                 DeleteObject(new JObject { ["name"] = "IntersectionPoint_point" });
                 DeleteObject(new JObject { ["name"] = "SplitSegment" });
                 DeleteObject(new JObject { ["name"] = "MCPDeltaProbe" });
+                DeleteObject(new JObject { ["name"] = "MCPMeasureA" });
+                DeleteObject(new JObject { ["name"] = "MCPMeasureB" });
+                DeleteObject(new JObject { ["name"] = "MCPMeasureC" });
+                DeleteObject(new JObject { ["name"] = "MCPMeasureBig" });
+                DeleteObject(new JObject { ["name"] = "MCPMeasureSmall" });
             }
             catch
             {

--- a/server/src/rhinomcp/server.py
+++ b/server/src/rhinomcp/server.py
@@ -90,6 +90,7 @@ READONLY_RETRY_COMMANDS = {
     "get_object_info",
     "get_object_attributes",
     "analyze_objects",
+    "measure_objects",
     "get_selected_objects_info",
     "get_document_summary",
     "get_objects",

--- a/server/src/rhinomcp/tools/measure_objects.py
+++ b/server/src/rhinomcp/tools/measure_objects.py
@@ -1,0 +1,35 @@
+from mcp.server.fastmcp import Context
+from mcp.types import ToolAnnotations
+from rhinomcp.server import get_rhino_connection, mcp
+from typing import Any, Dict, List
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+def measure_objects(
+    ctx: Context,
+    object_ids: List[str],
+) -> Dict[str, Any]:
+    """
+    Report the spatial relationship between two objects.
+
+    Parameters:
+    - object_ids: Exactly two object GUIDs to measure between.
+
+    Returns:
+    - object_a, object_b: the two object GUIDs
+    - clash: whether the two objects intersect
+    - intersection_count: number of intersections (brep curves+points, or curve
+      events); 0 for the bbox method
+    - bbox_gap: exact minimum distance between the two bounding boxes (0 if they
+      meet or overlap), a lower bound on the true surface-to-surface distance
+    - method: how clash was determined ("brep", "curve", or "bbox"). "bbox"
+      means the pair has no exact pairwise intersection here and overlap was
+      judged by bounding box, so read it as approximate.
+    """
+    if object_ids is None or len(object_ids) != 2:
+        raise ValueError(
+            "measure_objects requires object_ids with exactly two object ids."
+        )
+
+    rhino = get_rhino_connection()
+    return rhino.send_command("measure_objects", {"object_ids": object_ids})

--- a/server/src/rhinomcp/validation.py
+++ b/server/src/rhinomcp/validation.py
@@ -172,6 +172,7 @@ def validate_response(command_type: str, response: Dict[str, Any], raise_on_erro
         "get_object_attributes": "object_attributes.json",
         "update_object_attributes": "object_attributes.json",
         "analyze_objects": "analyze_objects_result.json",
+        "measure_objects": "measure_result.json",
         # get_selected_objects_info is deliberately unmapped: it returns
         # {"selected_objects": [...]}, which no current response schema
         # describes (object_info.json would reject it on every call).

--- a/server/tests/mock_rhino_server.py
+++ b/server/tests/mock_rhino_server.py
@@ -191,6 +191,7 @@ class MockRhinoServer:
             "get_object_attributes": self._get_object_attributes,
             "update_object_attributes": self._update_object_attributes,
             "analyze_objects": self._analyze_objects,
+            "measure_objects": self._measure_objects,
             "modify_object": self._modify_object,
             "modify_objects": self._modify_objects,
             "delete_object": self._delete_object,
@@ -495,6 +496,36 @@ class MockRhinoServer:
 
         analyses = [self._analysis_payload(obj) for obj in targets]
         return {"object_count": len(analyses), "analyses": analyses}
+
+    def _measure_objects(self, params: Dict) -> Dict:
+        """Spatial relationship between two objects. The mock has no real
+        geometry, so it reports the bbox method only, mirroring the plugin's
+        bounding-box gap math."""
+        ids = params.get("object_ids", [])
+        if len(ids) != 2:
+            raise Exception("measure_objects requires object_ids with exactly two object ids.")
+        a = self.objects.get(ids[0])
+        b = self.objects.get(ids[1])
+        if a is None or b is None:
+            raise Exception("measure_objects: object not found.")
+        gap = self._bbox_gap(
+            a.get("bounding_box", [[0, 0, 0], [0, 0, 0]]),
+            b.get("bounding_box", [[0, 0, 0], [0, 0, 0]]),
+        )
+        return {
+            "object_a": ids[0],
+            "object_b": ids[1],
+            "clash": gap <= 1e-9,
+            "intersection_count": 0,
+            "bbox_gap": gap,
+            "method": "bbox",
+        }
+
+    def _bbox_gap(self, a, b) -> float:
+        gx = max(0.0, max(a[0][0] - b[1][0], b[0][0] - a[1][0]))
+        gy = max(0.0, max(a[0][1] - b[1][1], b[0][1] - a[1][1]))
+        gz = max(0.0, max(a[0][2] - b[1][2], b[0][2] - a[1][2]))
+        return (gx * gx + gy * gy + gz * gz) ** 0.5
 
     def _analysis_payload(self, obj: Dict) -> Dict:
         bbox = obj.get("bounding_box", [[0, 0, 0], [0, 0, 0]])

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -786,3 +786,32 @@ class TestChangeDeltaPerception:
         assert "created_ids" not in d            # omitted because over the cap
         assert d["deleted_count"] == 0
         assert d["deleted_ids"] == []            # under the cap, so present
+
+
+class TestMeasureObjects:
+    """End-to-end measure_objects through the mock: verifies the command wiring
+    and the result shape. The exact spatial values come from real RhinoCommon
+    geometry, which the mock can't model, so those are covered by the live test;
+    here we pin that the contract shape arrives intact."""
+
+    def test_measure_two_objects(self, mock_server):
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+        srv._rhino_connection = None
+
+        conn = get_rhino_connection()
+        a = conn.send_command("create_object", {
+            "type": "BOX", "name": "MeasA",
+            "params": {"width": 1, "length": 1, "height": 1}})
+        b = conn.send_command("create_object", {
+            "type": "BOX", "name": "MeasB",
+            "params": {"width": 1, "length": 1, "height": 1}})
+
+        result = conn.send_command("measure_objects", {"object_ids": [a["id"], b["id"]]})
+
+        assert result["object_a"] == a["id"]
+        assert result["object_b"] == b["id"]
+        assert isinstance(result["clash"], bool)
+        assert result["bbox_gap"] >= 0
+        assert result["method"] in ("brep", "curve", "bbox")
+        assert result["intersection_count"] >= 0

--- a/server/tests/test_tools.py
+++ b/server/tests/test_tools.py
@@ -316,6 +316,39 @@ class TestModifyObjectTool:
         assert result["name"] == "NewName"
 
 
+class TestMeasureObjectsTool:
+    """Tests for measure_objects tool."""
+
+    @patch('rhinomcp.tools.measure_objects.get_rhino_connection')
+    def test_measure_objects(self, mock_get_conn):
+        from rhinomcp.tools.measure_objects import measure_objects
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "object_a": "a", "object_b": "b",
+            "clash": False, "intersection_count": 0,
+            "bbox_gap": 3.0, "method": "brep",
+        }
+        mock_get_conn.return_value = mock_conn
+
+        result = measure_objects(ctx=None, object_ids=["a", "b"])
+
+        call_args = mock_conn.send_command.call_args
+        assert call_args[0][0] == "measure_objects"
+        assert call_args[0][1]["object_ids"] == ["a", "b"]
+        assert result["clash"] is False
+        assert result["bbox_gap"] == 3.0
+        assert result["method"] == "brep"
+
+    def test_measure_objects_requires_exactly_two(self):
+        from rhinomcp.tools.measure_objects import measure_objects
+
+        with pytest.raises(ValueError, match="exactly two"):
+            measure_objects(ctx=None, object_ids=["only-one"])
+        with pytest.raises(ValueError, match="exactly two"):
+            measure_objects(ctx=None, object_ids=["a", "b", "c"])
+
+
 class TestObjectAttributesTools:
     """Tests for object attribute read/update tools."""
 


### PR DESCRIPTION
This is the spatial-reasoning step of the perception arc, after #33 and #34. Right now there is no way to ask how two objects relate in space. You can read each one's bounding box, but you can't ask "do these two parts collide" or "how close are they" without scripting it yourself.

measure_objects takes two object ids and reports their relationship:

```
{ "object_a", "object_b", "clash", "intersection_count", "bbox_gap", "method" }
```

clash is the real question, and it is exact where RhinoCommon gives an exact pairwise intersection: Intersection.BrepBrep for solids and surfaces, Intersection.CurveCurve for curves. For anything else (points, meshes, mixed curve and brep) it falls back to bounding-box overlap, and the method field always says which path was used, so you never read a bbox-based answer as if it were exact.

bbox_gap is the minimum distance between the two bounding boxes, 0 if they meet or overlap. It is exact bounding-box math and a conservative lower bound on the true surface distance. I deliberately did not try to return an exact surface-to-surface distance: RhinoCommon doesn't expose a clean brep-to-brep distance (I checked, there is no GetDistancesBetweenBreps), and I would rather ship the honest bbox gap than a sampled approximation dressed up as the real thing. It is emitted as a raw number so it isn't rounded by the point serializer.

I scoped this to two objects and these two questions on purpose. It is the smallest useful spatial primitive, and a clean template if anyone wants to add more along the same lines. Containment and nearest-N queries are the natural follow-ups.

Testing:
- pytest in server/, 176 passing. New: the wrapper enforces exactly two ids and forwards them, and end to end through the mock the result shape arrives intact.
- python contracts/test_schemas.py passing, with a measure_objects command schema (exactly two guids), a measure_result response schema, and negatives (wrong id count, bad guid, unknown method, missing field all rejected). The cross-tier sync check confirms protocol.json, the Python wrapper, and the C# handler all agree on the new command.
- dotnet build Release clean. Added an MCPTestCommand case that builds two boxes 10 apart (expects no clash, a positive gap, brep method) and an overlapping one (expects clash and a zero gap).
- verified against live Rhino 8 on real geometry, all three method paths: two solid boxes 10 apart came back clash=false, method=brep, gap=8; an overlapping pair came back clash=true, method=brep, gap=0 with 6 intersection curves; two crossing lines came back method=curve, clash=true; and a curve/brep pair correctly fell back to method=bbox. The bbox gap I checked against the value derived from each object's own bounding box, so it isn't just self-consistent.

The C# is a small MeasureObjects.cs: the handler plus two helpers, a geometry-to-brep converter matching the one analyze_objects already uses, and the bounding-box gap. It is ReadOnly, so no undo record. Happy to change the result shape or add modes if you would prefer something different.
