### PR TITLE
Add a geometry-health block to mutating-command responses

### DIFF
--- a/contracts/responses/change_health.json
+++ b/contracts/responses/change_health.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "change_health.json",
+  "title": "ChangeHealth",
+  "description": "Geometry-health report over the objects a mutating command just created (the same newly-created ids the change-delta reports). Attached as `_health` on the command result when the client opts in (envelope include_health=true). checked_count and invalid_count are always exact; the issues array lists only invalid objects with their reason and is capped, so a clean write returns an empty issues array. `truncated` is set when the issues list dropped some. Created geometry only, matching the change-delta scope.",
+  "type": "object",
+  "properties": {
+    "checked_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of newly-created objects whose geometry was checked."
+    },
+    "invalid_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "How many of the checked objects failed GeometryBase.IsValidWithLog."
+    },
+    "issues": {
+      "type": "array",
+      "description": "One entry per invalid object (valid objects are omitted). Capped; see truncated.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "../common/definitions.json#/$defs/guid",
+            "description": "GUID of the invalid object."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Human-readable validity log from RhinoCommon (e.g. 'Line points are coincident.')."
+          }
+        },
+        "required": ["id", "reason"],
+        "additionalProperties": false
+      }
+    },
+    "truncated": {
+      "type": "boolean",
+      "description": "True when invalid_count exceeded the cap and the issues list dropped some; the counts are still exact."
+    }
+  },
+  "required": ["checked_count", "invalid_count", "issues", "truncated"],
+  "additionalProperties": false
+}

--- a/contracts/test_schemas.py
+++ b/contracts/test_schemas.py
@@ -553,6 +553,51 @@ def test_responses():
             all_passed = False
     print("  change_delta negatives correctly rejected")
 
+    # Change health (perception). A clean write has an empty issues array; an
+    # invalid write lists each bad object with its validity reason.
+    print("  change_health:")
+    health_clean = {
+        "checked_count": 3,
+        "invalid_count": 0,
+        "issues": [],
+        "truncated": False,
+    }
+    if not validate("responses/change_health.json", health_clean):
+        all_passed = False
+    health_issue = {
+        "checked_count": 2,
+        "invalid_count": 1,
+        "issues": [{"id": GUID, "reason": "Line points are coincident."}],
+        "truncated": False,
+    }
+    if not validate("responses/change_health.json", health_issue):
+        all_passed = False
+
+    # Negative: the schema must actually constrain.
+    health_schema = load_schema_with_refs("responses/change_health.json")
+    health_validator = Draft202012Validator(health_schema)
+    bad_healths = [
+        # bad guid in an issue
+        {"checked_count": 1, "invalid_count": 1,
+         "issues": [{"id": "not-a-guid", "reason": "x"}], "truncated": False},
+        # issue missing its reason
+        {"checked_count": 1, "invalid_count": 1,
+         "issues": [{"id": GUID}], "truncated": False},
+        # issue carrying an unknown field
+        {"checked_count": 1, "invalid_count": 1,
+         "issues": [{"id": GUID, "reason": "x", "severity": "high"}], "truncated": False},
+        # unknown top-level field
+        {"checked_count": 0, "invalid_count": 0, "issues": [], "truncated": False,
+         "warnings": 2},
+        # missing required issues array
+        {"checked_count": 0, "invalid_count": 0, "truncated": False},
+    ]
+    for bad in bad_healths:
+        if not list(health_validator.iter_errors(bad)):
+            print(f"  FAIL: change_health accepted invalid payload {bad}")
+            all_passed = False
+    print("  change_health negatives correctly rejected")
+
     return all_passed
 
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -247,6 +247,42 @@ the counts stay exact. This follows the summarize-don't-enumerate approach
 validation. It is off by default, so responses are byte-identical unless
 enabled. See `contracts/responses/change_delta.json`.
 
+### Geometry Health (Perception)
+
+With `RHINO_MCP_PERCEPTION` enabled, the same envelope also carries an
+`include_health` flag, and the plugin attaches a `_health` block alongside
+`_delta` on each mutating command's `result`:
+
+```json
+{
+  "status": "success",
+  "result": {
+    "...": "normal command result",
+    "_health": {
+      "checked_count": 2,
+      "invalid_count": 1,
+      "issues": [
+        { "id": "...", "reason": "Line points are coincident." }
+      ],
+      "truncated": false
+    }
+  }
+}
+```
+
+Health is computed at the same dispatch choke point, over the objects the command
+just created (the `after - before` set the delta already derives). Each created
+object is checked with `GeometryBase.IsValidWithLog`, which returns the verdict
+and a human-readable reason in one pass; only the invalid ones are listed, so a
+clean write returns an empty `issues` array rather than a wall of "ok".
+`checked_count` and `invalid_count` are always exact; the `issues` list is capped
+at `HealthIssueCap` (50) with `truncated` set when some were dropped, the same
+summarize-don't-enumerate shape as the delta. Scope matches the delta: created
+geometry only, since an in-place modify reuses its id and can't be told apart by
+a set diff. The big win is the arbitrary-code and boolean/loft paths, where an
+invalid result can otherwise land silently. See
+`contracts/responses/change_health.json`.
+
 ### Schema Validation
 
 `server/src/rhinomcp/validation.py` validates tool parameters against
@@ -288,7 +324,7 @@ Main file: `server/src/rhinomcp/server.py`
 | `RHINO_MCP_PORT`         | `1999`            | TCP port.                                                                   |
 | `RHINO_MCP_ALLOW_REMOTE` | unset             | Set to `1` only if accepting unauthenticated remote command execution risk. |
 | `RHINO_MCP_TIMEOUT`      | `15.0`            | Socket timeout in seconds.                                                  |
-| `RHINO_MCP_PERCEPTION`   | unset             | Set truthy to attach a `_delta` change block to mutating-command results.   |
+| `RHINO_MCP_PERCEPTION`   | unset             | Set truthy to attach `_delta` (what changed) and `_health` (validity of created geometry) blocks to mutating-command results. |
 | `RHINO_MCP_DEBUG`        | unset             | Enables verbose logging when truthy.                                        |
 | `RHINO_MCP_LOG_LEVEL`    | `INFO` or `DEBUG` | Explicit Python logging level.                                              |
 

--- a/plugin/Functions/Perception.cs
+++ b/plugin/Functions/Perception.cs
@@ -86,4 +86,67 @@ public partial class RhinoMCPFunctions
 
         return delta;
     }
+
+    /// <summary>
+    /// The issues list is capped so a pathological write that produces many
+    /// invalid objects can't flood the response. invalid_count is always exact;
+    /// the issues array holds at most this many entries, and the health block's
+    /// `truncated` flag is set when some were dropped. Same summarize-don't-
+    /// enumerate shape as the change-delta.
+    /// </summary>
+    public const int HealthIssueCap = 50;
+
+    /// <summary>
+    /// Build a geometry-health report over the objects a command just created
+    /// (the set difference after - before, the same newly-created ids the
+    /// change-delta reports). Each created object is checked with
+    /// GeometryBase.IsValidWithLog, which returns the verdict and a human-readable
+    /// reason in one pass. checked_count and invalid_count are always exact; only
+    /// the invalid objects are listed, with their reason, so a clean write returns
+    /// an empty issues array rather than a wall of "ok".
+    ///
+    /// Scope mirrors the change-delta: created geometry only. An in-place modify
+    /// reuses its id, so it can't be told apart by a set diff, and validity rarely
+    /// changes under a rigid transform; rather than special-case it per handler at
+    /// the cost of a half-covered field, this reports the new geometry that every
+    /// mutator funnels through here produces. The big win is the arbitrary-code and
+    /// boolean/loft paths, where an invalid result can otherwise land silently.
+    /// </summary>
+    public JObject BuildHealth(RhinoDoc doc, HashSet<Guid> before, HashSet<Guid> after)
+    {
+        before ??= new HashSet<Guid>();
+        after ??= new HashSet<Guid>();
+
+        int checkedCount = 0;
+        int invalidCount = 0;
+        var issues = new JArray();
+
+        foreach (var id in after)
+        {
+            if (before.Contains(id)) continue;            // only newly created objects
+            var geo = doc?.Objects.FindId(id)?.Geometry;
+            if (geo == null) continue;                    // not resolvable / nothing to judge
+            checkedCount++;
+            if (!geo.IsValidWithLog(out string log))
+            {
+                invalidCount++;
+                if (issues.Count < HealthIssueCap)
+                {
+                    issues.Add(new JObject
+                    {
+                        ["id"] = id.ToString(),
+                        ["reason"] = (log ?? "").Trim()
+                    });
+                }
+            }
+        }
+
+        return new JObject
+        {
+            ["checked_count"] = checkedCount,
+            ["invalid_count"] = invalidCount,
+            ["issues"] = issues,
+            ["truncated"] = invalidCount > HealthIssueCap
+        };
+    }
 }

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -871,6 +871,56 @@ public partial class RhinoMCPFunctions
             results["layer_name_live"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
         }
 
+        // Test 26: change-health helper (Scene Perception Layer). BuildHealth runs
+        // GeometryBase.IsValidWithLog over the newly-created objects. Create one
+        // valid object and add one genuinely invalid curve (a zero-length line,
+        // which the document accepts but reports invalid), then assert only the
+        // bad one is listed, with a reason, and the counts are exact.
+        try
+        {
+            var healthBefore = SnapshotObjectIds(doc);
+            var okBox = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPHealthOk",
+                ["params"] = new JObject { ["width"] = 1, ["length"] = 1, ["height"] = 1 }
+            });
+            string okId = okBox["id"]?.ToString();
+            var badId = doc.Objects.AddCurve(new Rhino.Geometry.LineCurve(
+                new Rhino.Geometry.Point3d(0, 0, 0), new Rhino.Geometry.Point3d(0, 0, 0)));
+
+            var health = BuildHealth(doc, healthBefore, SnapshotObjectIds(doc));
+            if ((int)health["checked_count"] != 2)
+                throw new Exception("BuildHealth checked_count should be 2, got " + health["checked_count"]);
+            if ((int)health["invalid_count"] != 1)
+                throw new Exception("BuildHealth invalid_count should be 1, got " + health["invalid_count"]);
+            if ((bool)health["truncated"])
+                throw new Exception("BuildHealth marked a single issue truncated");
+            var issues = (JArray)health["issues"];
+            if (issues.Count != 1)
+                throw new Exception("BuildHealth should list exactly one issue, got " + issues.Count);
+            if (issues[0]["id"].ToString() != badId.ToString())
+                throw new Exception("BuildHealth flagged the wrong object");
+            if (string.IsNullOrWhiteSpace(issues[0]["reason"]?.ToString()))
+                throw new Exception("BuildHealth issue is missing a reason");
+            foreach (var it in issues)
+                if (it["id"].ToString() == okId)
+                    throw new Exception("BuildHealth listed the valid object as an issue");
+
+            doc.Objects.Delete(badId, true);
+            DeleteObject(new JObject { ["id"] = okId });
+            results["change_health"] = new JObject
+            {
+                ["status"] = "pass",
+                ["reason"] = issues[0]["reason"]
+            };
+            VisualUpdate("change-health flags invalid created geometry");
+        }
+        catch (Exception e)
+        {
+            results["change_health"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
         // Cleanup
         if (!visualMode)
         {
@@ -891,6 +941,7 @@ public partial class RhinoMCPFunctions
                 DeleteObject(new JObject { ["name"] = "IntersectionPoint_point" });
                 DeleteObject(new JObject { ["name"] = "SplitSegment" });
                 DeleteObject(new JObject { ["name"] = "MCPDeltaProbe" });
+                DeleteObject(new JObject { ["name"] = "MCPHealthOk" });
             }
             catch
             {

--- a/plugin/RhinoMCPServer.cs
+++ b/plugin/RhinoMCPServer.cs
@@ -420,10 +420,11 @@ namespace RhinoMCPPlugin
                 // so it never collides with a command's own parameters. Defaults
                 // off, so behavior is unchanged unless a client asks for it.
                 bool includeDelta = command["include_delta"]?.ToObject<bool>() ?? false;
+                bool includeHealth = command["include_health"]?.ToObject<bool>() ?? false;
 
                 RhinoApp.WriteLine($"Executing command: {cmdType}");
 
-                JObject result = ExecuteCommandInternal(cmdType, parameters, includeDelta);
+                JObject result = ExecuteCommandInternal(cmdType, parameters, includeDelta, includeHealth);
 
                 RhinoApp.WriteLine("Command execution complete");
                 return result;
@@ -439,7 +440,7 @@ namespace RhinoMCPPlugin
             }
         }
 
-        private JObject ExecuteCommandInternal(string cmdType, JObject parameters, bool includeDelta)
+        private JObject ExecuteCommandInternal(string cmdType, JObject parameters, bool includeDelta, bool includeHealth)
         {
             // Reflection-discovered dispatch table — see Functions/_Registry.cs.
             // Adding a new command means adding a [McpCommand("name")] method on
@@ -458,14 +459,17 @@ namespace RhinoMCPPlugin
             var doc = RhinoDoc.ActiveDoc;
             bool needsUndo = !entry.ReadOnly;
 
-            // A change-delta only makes sense for a mutating command, and only
-            // when the client asked for it. Snapshot the document's object ids
-            // just before the handler runs so we can diff against the post-state.
-            // This is the one place every mutator funnels through, so it covers
-            // them all (including multi-effect ones like run_command and booleans
-            // with delete_sources) with no per-handler changes.
+            // A change-delta or health report only makes sense for a mutating
+            // command, and only when the client asked for it. Snapshot the
+            // document's object ids just before the handler runs so we can diff
+            // against the post-state. This is the one place every mutator funnels
+            // through, so it covers them all (including multi-effect ones like
+            // run_command and booleans with delete_sources) with no per-handler
+            // changes.
             bool wantDelta = includeDelta && needsUndo && doc != null;
-            HashSet<Guid> idsBefore = wantDelta ? this.handler.SnapshotObjectIds(doc) : null;
+            bool wantHealth = includeHealth && needsUndo && doc != null;
+            HashSet<Guid> idsBefore = (wantDelta || wantHealth)
+                ? this.handler.SnapshotObjectIds(doc) : null;
 
             uint record = 0;
             if (needsUndo)
@@ -476,10 +480,18 @@ namespace RhinoMCPPlugin
             try
             {
                 JObject result = entry.Handler(parameters);
-                if (wantDelta && result != null)
+                if ((wantDelta || wantHealth) && result != null)
                 {
-                    result["_delta"] = this.handler.BuildDelta(
-                        idsBefore, this.handler.SnapshotObjectIds(doc));
+                    var idsAfter = this.handler.SnapshotObjectIds(doc);
+                    if (wantDelta) result["_delta"] = this.handler.BuildDelta(idsBefore, idsAfter);
+                    // Health walks RhinoCommon geometry, so keep it from ever
+                    // turning a successful mutation into a failure: a hiccup
+                    // degrades to no _health rather than throwing out the result.
+                    if (wantHealth)
+                    {
+                        try { result["_health"] = this.handler.BuildHealth(doc, idsBefore, idsAfter); }
+                        catch (Exception he) { RhinoApp.WriteLine($"health check skipped: {he.Message}"); }
+                    }
                 }
                 return new JObject
                 {

--- a/server/src/rhinomcp/server.py
+++ b/server/src/rhinomcp/server.py
@@ -254,10 +254,13 @@ class RhinoConnection:
 
         command = {"type": command_type, "params": params or {}}
         if RHINO_PERCEPTION:
-            # Envelope-level flag, kept out of params so it never collides with a
-            # command's own parameters or trips params schema validation. The
-            # plugin ignores it for read-only commands.
+            # Envelope-level flags, kept out of params so they never collide with a
+            # command's own parameters or trip params schema validation. The plugin
+            # ignores them for read-only commands. Perception is the master switch
+            # for the whole perceive-act loop: what changed (_delta) and whether the
+            # new geometry is sound (_health).
             command["include_delta"] = True
+            command["include_health"] = True
 
         try:
             # Log the command being sent

--- a/server/tests/mock_rhino_server.py
+++ b/server/tests/mock_rhino_server.py
@@ -225,11 +225,17 @@ class MockRhinoServer:
             track_delta = bool(command.get("include_delta")) and (
                 cmd_type in self._MUTATING_COMMANDS
             )
-            before = set(self.objects.keys()) if track_delta else None
+            track_health = bool(command.get("include_health")) and (
+                cmd_type in self._MUTATING_COMMANDS
+            )
+            before = set(self.objects.keys()) if (track_delta or track_health) else None
             result = handler(params)
-            if track_delta and isinstance(result, dict):
+            if isinstance(result, dict) and (track_delta or track_health):
                 after = set(self.objects.keys())
-                result["_delta"] = self._build_delta(before, after)
+                if track_delta:
+                    result["_delta"] = self._build_delta(before, after)
+                if track_health:
+                    result["_health"] = self._build_health(before, after)
             return {"status": "success", "result": result}
         except Exception as e:
             return {"status": "error", "message": str(e)}
@@ -258,6 +264,19 @@ class MockRhinoServer:
             truncated = True
         delta["truncated"] = truncated
         return delta
+
+    def _build_health(self, before: set, after: set) -> Dict:
+        """Mirror the plugin's BuildHealth shape over the created objects. The
+        mock holds no real geometry, so every created object is treated as valid;
+        this exercises the wiring and the all-clear shape. The invalid path is
+        covered by the C# unit test, the live test, and the schema test."""
+        created = [k for k in after if k not in before]
+        return {
+            "checked_count": len(created),
+            "invalid_count": 0,
+            "issues": [],
+            "truncated": False,
+        }
 
     def _get_document_summary(self, params: Dict) -> Dict:
         """Return document summary."""

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -786,3 +786,97 @@ class TestChangeDeltaPerception:
         assert "created_ids" not in d            # omitted because over the cap
         assert d["deleted_count"] == 0
         assert d["deleted_ids"] == []            # under the cap, so present
+
+
+class TestChangeHealthPerception:
+    """End-to-end: with perception enabled the server forwards include_health and
+    mutating commands come back with a _health block reporting how many created
+    objects were checked and which were invalid. The mock holds no real geometry,
+    so it reports the all-clear shape; the invalid path is covered by the C# unit
+    test, the live test, and the schema test."""
+
+    def _enable(self):
+        import rhinomcp.server as srv
+        srv._rhino_connection = None
+        srv.RHINO_PERCEPTION = True
+
+    def _restore(self, value):
+        import rhinomcp.server as srv
+        srv.RHINO_PERCEPTION = value
+        srv._rhino_connection = None
+
+    def test_create_carries_health_when_enabled(self, mock_server):
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        self._enable()
+        try:
+            conn = get_rhino_connection()
+            result = conn.send_command("create_object", {
+                "type": "BOX", "name": "HealthBox",
+                "params": {"width": 1, "length": 1, "height": 1},
+            })
+        finally:
+            self._restore(original)
+
+        assert "_health" in result
+        h = result["_health"]
+        assert h["checked_count"] == 1
+        assert h["invalid_count"] == 0
+        assert h["issues"] == []
+        assert h["truncated"] is False
+
+    def test_perception_carries_both_delta_and_health(self, mock_server):
+        """RHINO_PERCEPTION is one master switch, so a mutating command comes
+        back with both perception blocks."""
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        self._enable()
+        try:
+            conn = get_rhino_connection()
+            result = conn.send_command("create_object", {
+                "type": "BOX", "name": "BothBox",
+                "params": {"width": 1, "length": 1, "height": 1},
+            })
+        finally:
+            self._restore(original)
+
+        assert "_delta" in result and "_health" in result
+        assert result["_delta"]["created_count"] == 1
+        assert result["_health"]["checked_count"] == 1
+
+    def test_no_health_when_disabled(self, mock_server):
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        srv._rhino_connection = None
+        srv.RHINO_PERCEPTION = False
+        try:
+            conn = get_rhino_connection()
+            result = conn.send_command("create_object", {
+                "type": "BOX", "name": "NoHealthBox",
+                "params": {"width": 1, "length": 1, "height": 1},
+            })
+        finally:
+            self._restore(original)
+
+        assert "_health" not in result
+
+    def test_readonly_has_no_health(self, mock_server):
+        """Read-only commands never carry a _health, even with perception on."""
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        self._enable()
+        try:
+            conn = get_rhino_connection()
+            result = conn.send_command("get_document_summary", {})
+        finally:
+            self._restore(original)
+
+        assert "_health" not in result


### PR DESCRIPTION
This is the next step of the perception arc, after the bounding-box passthrough (#33) and the change-delta (#34). The change-delta tells an agent what changed; this tells it whether what it just made is sound. Right now a write can land invalid geometry in the document and the response looks exactly like a clean one, so the agent keeps building on something broken without knowing.

With perception enabled the plugin attaches a `_health` block to every mutating command's result, next to `_delta`:

```
"_health": {
  "checked_count": 2,
  "invalid_count": 1,
  "issues": [ { "id": "...", "reason": "Line points are coincident." } ],
  "truncated": false
}
```

It checks the objects the command just created (the same after-minus-before set the delta already derives) with GeometryBase.IsValidWithLog, which gives the verdict and a human-readable reason in one call. Only the invalid objects are listed, with their reason, so a clean write comes back with an empty issues array instead of a wall of "ok". checked_count and invalid_count are always exact; the issues list is capped (50) with truncated set when it drops one, the same summarize-don't-enumerate shape the delta uses.

It hangs off the same dispatch choke point as the delta (ExecuteCommandInternal), so it covers every mutator with no per-handler code, and reuses the one post-handler snapshot the delta already takes. I gated it on its own envelope flag, include_health, so the two signals are independent at the protocol level; RHINO_MCP_PERCEPTION turns the whole loop on as one switch. Off by default, so responses are byte-identical unless a client asks.

I scoped it to created geometry on purpose, matching the delta. An in-place modify reuses its id, so a set diff can't single it out, and validity rarely changes under a rigid transform; I would rather report the new geometry cleanly than ship a half-covered field. The real payoff is the arbitrary-code and boolean/loft paths, where an invalid result otherwise lands silently. I kept it to validity for now (the unambiguous signal); closed-vs-open solid status is the natural next field if you want it.

Testing:
- pytest in server/, 177 passing. New: end to end through the mock, a mutating command carries a `_health` (and both `_delta` and `_health` together, since perception is one switch), a read-only command never does, and nothing changes when perception is off.
- python contracts/test_schemas.py passing, with a change_health response schema and negatives (bad guid in an issue, issue missing its reason, unknown fields, missing required arrays all rejected).
- dotnet build Release clean. Added an MCPTestCommand case that creates one valid object and adds one genuinely invalid curve, then asserts only the bad one is listed with a reason.
- verified against live Rhino 8 on real geometry: a valid box came back checked_count=1, invalid_count=0; arbitrary code that adds a zero-length curve (the document accepts it, IsValidWithLog rejects it) came back invalid_count=1 with the object's id and reason "Line points are coincident."; a mixed write of one valid line and one invalid curve listed only the bad one; a batch of three valid boxes was all-clear; a delete reported checked_count=0; and read-only commands carried no _health. Every live _health block validated against change_health.json.

The C# is small: a BuildHealth helper in Perception.cs next to BuildDelta, plus reading the include_health flag at the choke point. It is read-only work on the created set, so no extra undo records. The health check is wrapped so a validity-check hiccup degrades to no _health rather than failing the command it is reporting on. Happy to rename the block, change the fields, or add the closed-solid signal if you would prefer something different.
