### PR TITLE
Fix delete_object returning a null name for unnamed objects

### DIFF
--- a/contracts/test_schemas.py
+++ b/contracts/test_schemas.py
@@ -424,6 +424,19 @@ def test_responses():
     delete_result = {"id": "12345678-1234-1234-1234-123456789012", "name": "Deleted", "deleted": True}
     if not validate("responses/delete_result.json", delete_result):
         all_passed = False
+    # Deleting an unnamed object reports the "(unnamed)" fallback, never null.
+    # name is typed as a string, so a null is a regression: it made deleting a
+    # nameless object fail response validation under strict mode.
+    unnamed_delete = {"id": "12345678-1234-1234-1234-123456789012", "name": "(unnamed)", "deleted": True}
+    if not validate("responses/delete_result.json", unnamed_delete):
+        all_passed = False
+    delete_validator = Draft202012Validator(load_schema_with_refs("responses/delete_result.json"))
+    null_name = {"id": "12345678-1234-1234-1234-123456789012", "name": None, "deleted": True}
+    if not list(delete_validator.iter_errors(null_name)):
+        print("  FAIL: delete_result accepted a null name")
+        all_passed = False
+    else:
+        print("  delete_result rejects a null name")
 
     # Execute script result
     print("  execute_script_result:")

--- a/plugin/Functions/DeleteObject.cs
+++ b/plugin/Functions/DeleteObject.cs
@@ -49,8 +49,12 @@ public partial class RhinoMCPFunctions
 
         return new JObject
         {
+            // Coalesce to match Serializer.RhinoObject: an object with no name
+            // reports "(unnamed)", never null. delete_result.json types name as a
+            // string, so emitting null here made deleting an unnamed object fail
+            // response validation.
             ["id"] = obj.Id,
-            ["name"] = obj.Name,
+            ["name"] = obj.Name ?? "(unnamed)",
             ["deleted"] = true
         };
     }

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -569,6 +569,30 @@ public partial class RhinoMCPFunctions
             results["delete_object"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
         }
 
+        // Test 19b: deleting an UNNAMED object must report the "(unnamed)"
+        // fallback, never null. A null name made delete_result fail response
+        // validation under strict mode.
+        try
+        {
+            var lineId = doc.Objects.AddLine(
+                new Rhino.Geometry.Point3d(0, 0, 0), new Rhino.Geometry.Point3d(3, 0, 0));
+            if (lineId == Guid.Empty)
+                throw new Exception("could not add an unnamed line to test with");
+
+            var res = DeleteObject(new JObject { ["id"] = lineId.ToString() });
+            if (!(res["deleted"]?.ToObject<bool>() ?? false))
+                throw new Exception("unnamed object was not deleted");
+            var name = res["name"]?.ToString();
+            if (name != "(unnamed)")
+                throw new Exception("expected name '(unnamed)' for a nameless object, got '" + (name ?? "null") + "'");
+            results["delete_unnamed_object"] = new JObject { ["status"] = "pass", ["name"] = name };
+            VisualUpdate("Deleted unnamed object reports (unnamed)");
+        }
+        catch (Exception e)
+        {
+            results["delete_unnamed_object"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
         // Test 20: DeleteLayer
         try
         {


### PR DESCRIPTION
Deleting an object that has no name makes delete_object return `"name": null`, which fails its own response schema: delete_result.json types name as a string. With response validation in strict mode (RHINO_MCP_VALIDATE=strict) the delete then raises after the object is already gone, so a successful operation reports as a failure.

The cause is a one-line inconsistency. Everywhere else an object name is serialized, the plugin coalesces it, for example Serializer.RhinoObject does `obj.Name ?? "(unnamed)"`. DeleteObject is the one place that emitted `obj.Name` straight, so a nameless object came back as null. The fix is to match the same convention so a deleted unnamed object reports "(unnamed)", the same string it would show anywhere else.

I ran into this while testing measure_objects (#35): the live test deletes a couple of unnamed helper curves at the end, and under strict validation those deletes tripped on the null name.

Testing:
- verified the before and after live on Rhino 8 under strict response validation: before the fix, deleting an unnamed object failed with "None is not of type 'string'"; after, that same delete succeeds and returns name "(unnamed)", while a named delete still reports its real name. Also covered by a new in-plugin test (adds an unnamed line, deletes it, asserts the response name) and the schema test below.
- python contracts/test_schemas.py: added a delete_result check that a null name is rejected (so the schema keeps the contract) and that the "(unnamed)" fallback is accepted.
- dotnet build Release clean, with a new in-plugin test that adds an unnamed line, deletes it, and asserts the response name is "(unnamed)".

It is a one-line change in DeleteObject.cs plus tests. No schema change: name is correctly a string, the plugin just has to uphold it.
