### PR TITLE
Add a describe_capabilities command for MCP self-description

### DIFF
--- a/contracts/commands/describe_capabilities.json
+++ b/contracts/commands/describe_capabilities.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "describe_capabilities.json",
+  "title": "DescribeCapabilities Command",
+  "description": "Describe the MCP server's own command surface: every command it handles and whether each is read-only, the perception envelope flags it honors, and the plugin version. Distinct from get_commands, which lists Rhino's own application commands.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/contracts/protocol.json
+++ b/contracts/protocol.json
@@ -48,6 +48,7 @@
             "split_curve",
             "run_command",
             "get_commands",
+            "describe_capabilities",
             "gh_create_document",
             "gh_get_document_info",
             "gh_search_components",

--- a/contracts/responses/capabilities.json
+++ b/contracts/responses/capabilities.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "capabilities.json",
+  "title": "Capabilities",
+  "description": "Self-description returned by describe_capabilities: the MCP command surface (each command and whether it is read-only), the perception envelope flags the server honors, and the plugin version.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Plugin version."
+    },
+    "command_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of commands the server handles."
+    },
+    "commands": {
+      "type": "array",
+      "description": "Every command the server handles, sorted by name.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Command type, e.g. create_object."
+          },
+          "read_only": {
+            "type": "boolean",
+            "description": "True if the command does not mutate the document (no undo record)."
+          }
+        },
+        "required": ["name", "read_only"],
+        "additionalProperties": false
+      }
+    },
+    "perception": {
+      "type": "object",
+      "description": "Opt-in envelope flags that attach extra feedback to a mutating command's result.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "How the perception flags are enabled."
+        },
+        "envelope_flags": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "flag": {
+                "type": "string",
+                "description": "Envelope flag name, e.g. include_delta."
+              },
+              "attaches": {
+                "type": "string",
+                "description": "The result block it attaches, e.g. _delta."
+              },
+              "description": {
+                "type": "string",
+                "description": "What the flag does."
+              }
+            },
+            "required": ["flag", "attaches", "description"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["description", "envelope_flags"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["version", "command_count", "commands", "perception"],
+  "additionalProperties": false
+}

--- a/contracts/test_schemas.py
+++ b/contracts/test_schemas.py
@@ -445,6 +445,55 @@ def test_responses():
     if not validate("responses/execute_script_result.json", script_result):
         all_passed = False
 
+    # Capabilities (describe_capabilities). The command list and perception flags
+    # may be empty; the shape must still hold.
+    print("  capabilities:")
+    capabilities = {
+        "version": "0.3.1",
+        "command_count": 2,
+        "commands": [
+            {"name": "create_object", "read_only": False},
+            {"name": "get_objects", "read_only": True},
+        ],
+        "perception": {
+            "description": "Mutating commands accept opt-in envelope flags.",
+            "envelope_flags": [
+                {"flag": "include_delta", "attaches": "_delta",
+                 "description": "Attaches a change-delta."},
+                {"flag": "include_health", "attaches": "_health",
+                 "description": "Attaches a geometry-health report."},
+            ],
+        },
+    }
+    if not validate("responses/capabilities.json", capabilities):
+        all_passed = False
+    minimal_caps = {"version": "0", "command_count": 0, "commands": [],
+                    "perception": {"description": "none", "envelope_flags": []}}
+    if not validate("responses/capabilities.json", minimal_caps):
+        all_passed = False
+    caps_validator = Draft202012Validator(load_schema_with_refs("responses/capabilities.json"))
+    bad_caps = [
+        # a command missing read_only
+        {"version": "0.3.1", "command_count": 1, "commands": [{"name": "x"}],
+         "perception": {"description": "d", "envelope_flags": []}},
+        # read_only not a boolean
+        {"version": "0.3.1", "command_count": 1, "commands": [{"name": "x", "read_only": "yes"}],
+         "perception": {"description": "d", "envelope_flags": []}},
+        # unknown top-level field
+        {"version": "0.3.1", "command_count": 0, "commands": [],
+         "perception": {"description": "d", "envelope_flags": []}, "extra": 1},
+        # missing perception
+        {"version": "0.3.1", "command_count": 0, "commands": []},
+        # envelope flag missing attaches
+        {"version": "0.3.1", "command_count": 0, "commands": [],
+         "perception": {"description": "d", "envelope_flags": [{"flag": "include_delta", "description": "d"}]}},
+    ]
+    for bad in bad_caps:
+        if not list(caps_validator.iter_errors(bad)):
+            print(f"  FAIL: capabilities accepted invalid payload {bad}")
+            all_passed = False
+    print("  capabilities negatives correctly rejected")
+
     # Layer info
     print("  layer_info:")
     layer_info = {

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -282,6 +282,22 @@ geometry only, since an in-place modify reuses its id and can't be told apart by
 a set diff. The big win is the arbitrary-code and boolean/loft paths, where an
 invalid result can otherwise land silently. See
 `contracts/responses/change_health.json`.
+### Capabilities (Self-Description)
+
+`describe_capabilities` returns what this server itself can do: every command it
+handles with a `read_only` flag, the perception envelope flags it honors, and the
+plugin version. The command list is built from the live dispatch table
+(`GetDispatchTable`), so it can't drift from what the server actually accepts;
+adding a `[McpCommand]` makes it appear automatically.
+
+This is deliberately distinct from `get_commands`, which lists Rhino's own
+application commands (`Box`, `Circle`, ...) for use with `run_command`.
+`describe_capabilities` describes the MCP command surface, so an agent can
+discover what it can send here rather than guessing. Parameters are not included:
+the handlers take an untyped payload, so there is no parameter schema to reflect
+at runtime; the authoritative shapes live in `contracts/` and are already
+surfaced to clients through the MCP tool list. See
+`contracts/responses/capabilities.json`.
 
 ### Schema Validation
 
@@ -424,7 +440,7 @@ commands and 25 Grasshopper commands.
 | Object attributes             | `update_object_attributes`                                                                                                                            |
 | Selection                     | `select_objects`                                                                                                                                      |
 | Layers                        | `create_layer`, `delete_layer`, `get_or_set_current_layer`                                                                                            |
-| Scripting and commands        | `run_command`, `get_commands`, `execute_rhinoscript_python_code`, `execute_rhinocommon_csharp_code`                                                   |
+| Scripting and commands        | `run_command`, `get_commands`, `describe_capabilities`, `execute_rhinoscript_python_code`, `execute_rhinocommon_csharp_code`                          |
 | Undo                          | `undo`, `redo`                                                                                                                                        |
 | Booleans                      | `boolean_union`, `boolean_difference`, `boolean_intersection`                                                                                         |
 | Curves and generated geometry | `loft`, `extrude_curve`, `sweep1`, `offset_curve`, `pipe`, `project_curve`, `intersect_curves`, `split_curve`                                         |

--- a/plugin/Functions/DescribeCapabilities.cs
+++ b/plugin/Functions/DescribeCapabilities.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json.Linq;
+
+namespace RhinoMCPPlugin.Functions;
+
+public partial class RhinoMCPFunctions
+{
+    /// <summary>
+    /// Self-description of what this MCP server can do: every command it handles
+    /// and whether that command is read-only, plus the perception envelope flags
+    /// it honors and the plugin version. Read-only.
+    ///
+    /// This is distinct from get_commands, which lists Rhino's own application
+    /// commands (Box, Circle, ...) for use with run_command. describe_capabilities
+    /// lists the MCP command surface itself, so an agent can discover what it can
+    /// send instead of guessing. The command list is the live dispatch table
+    /// (GetDispatchTable), so it never drifts from what the server actually
+    /// accepts: add a [McpCommand] and it appears here automatically.
+    ///
+    /// Parameters are deliberately not included. The handlers take an untyped
+    /// JObject, so there is no parameter schema to reflect at runtime; the
+    /// authoritative parameter shapes live in the contracts/ schemas and are
+    /// already surfaced to clients through the MCP tool list.
+    /// </summary>
+    [McpCommand("describe_capabilities", ReadOnly = true)]
+    public JObject DescribeCapabilities(JObject parameters)
+    {
+        var table = GetDispatchTable();
+
+        var commands = new JArray();
+        foreach (var name in table.Keys.OrderBy(n => n, StringComparer.Ordinal))
+        {
+            commands.Add(new JObject
+            {
+                ["name"] = name,
+                ["read_only"] = table[name].ReadOnly
+            });
+        }
+
+        // Opt-in envelope flags the dispatcher honors (see ExecuteCommandInternal).
+        // Each attaches an extra feedback block to a mutating command's result.
+        var envelopeFlags = new JArray
+        {
+            new JObject
+            {
+                ["flag"] = "include_delta",
+                ["attaches"] = "_delta",
+                ["description"] = "Attaches a change-delta (created/deleted ids and counts) to a mutating command's result."
+            },
+            new JObject
+            {
+                ["flag"] = "include_health",
+                ["attaches"] = "_health",
+                ["description"] = "Attaches a geometry-health report (created/modified objects that fail validity checks, with reasons) to a mutating command's result."
+            }
+        };
+
+        return new JObject
+        {
+            ["version"] = GetPluginVersion(),
+            ["command_count"] = commands.Count,
+            ["commands"] = commands,
+            ["perception"] = new JObject
+            {
+                ["description"] = "Mutating commands accept opt-in envelope flags that attach extra feedback to the result. Set them per command on the envelope, or globally with the RHINO_MCP_PERCEPTION server setting.",
+                ["envelope_flags"] = envelopeFlags
+            }
+        };
+    }
+
+    /// <summary>Plugin version without the build-metadata (+commit) suffix.</summary>
+    private static string GetPluginVersion()
+    {
+        var asm = typeof(RhinoMCPFunctions).Assembly;
+        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrEmpty(info))
+        {
+            int plus = info.IndexOf('+');
+            return plus >= 0 ? info.Substring(0, plus) : info;
+        }
+        return asm.GetName().Version?.ToString() ?? "unknown";
+    }
+}

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -1092,6 +1092,54 @@ public partial class RhinoMCPFunctions
             results["live_object_count"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
         }
 
+        // Test: describe_capabilities reports the live dispatch table with
+        // read-only flags, the perception envelope flags, and the version. The
+        // command list is reflection-driven, so it must include the commands we
+        // exercise here and describe_capabilities itself, with correct read_only.
+        try
+        {
+            var caps = DescribeCapabilities(new JObject());
+            var cmds = (JArray)caps["commands"];
+            if ((int)caps["command_count"] != cmds.Count)
+                throw new Exception("command_count does not match the commands array length");
+            if (string.IsNullOrWhiteSpace(caps["version"]?.ToString()))
+                throw new Exception("version is empty");
+
+            var readOnly = new System.Collections.Generic.Dictionary<string, bool>();
+            foreach (var c in cmds)
+                readOnly[c["name"].ToString()] = (bool)c["read_only"];
+
+            if (!readOnly.ContainsKey("describe_capabilities") || !readOnly["describe_capabilities"])
+                throw new Exception("describe_capabilities should list itself as read_only");
+            if (!readOnly.ContainsKey("create_object") || readOnly["create_object"])
+                throw new Exception("create_object should be present and not read_only");
+            if (!readOnly.ContainsKey("get_document_summary") || !readOnly["get_document_summary"])
+                throw new Exception("get_document_summary should be present and read_only");
+
+            bool hasDelta = false, hasHealth = false;
+            foreach (var f in (JArray)caps["perception"]["envelope_flags"])
+            {
+                if (f["flag"]?.ToString() == "include_delta") hasDelta = true;
+                if (f["flag"]?.ToString() == "include_health") hasHealth = true;
+            }
+            if (!hasDelta)
+                throw new Exception("perception should advertise include_delta");
+            if (!hasHealth)
+                throw new Exception("perception should advertise include_health");
+
+            results["describe_capabilities"] = new JObject
+            {
+                ["status"] = "pass",
+                ["command_count"] = (int)caps["command_count"],
+                ["version"] = caps["version"]
+            };
+            VisualUpdate("describe_capabilities lists the command surface");
+        }
+        catch (Exception e)
+        {
+            results["describe_capabilities"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
         // Cleanup
         if (!visualMode)
         {

--- a/server/src/rhinomcp/server.py
+++ b/server/src/rhinomcp/server.py
@@ -96,6 +96,7 @@ READONLY_RETRY_COMMANDS = {
     "get_objects",
     "capture_viewport",
     "get_commands",
+    "describe_capabilities",
     "gh_get_document_info",
     "gh_search_components",
     "gh_batch_search_components",

--- a/server/src/rhinomcp/tools/describe_capabilities.py
+++ b/server/src/rhinomcp/tools/describe_capabilities.py
@@ -1,0 +1,25 @@
+from mcp.server.fastmcp import Context
+from mcp.types import ToolAnnotations
+from rhinomcp.server import get_rhino_connection, mcp
+from typing import Any, Dict
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+def describe_capabilities(ctx: Context) -> Dict[str, Any]:
+    """
+    Describe what this MCP server itself can do.
+
+    Unlike get_commands, which lists Rhino's own application commands (Box,
+    Circle, ...) for use with run_command, this lists the MCP command surface:
+    every command the server handles and whether it is read-only, so you can
+    discover what is callable here instead of guessing a name.
+
+    Returns:
+    - version: the plugin version
+    - command_count: how many commands the server handles
+    - commands: a list of {name, read_only}, sorted by name
+    - perception: the opt-in envelope flags (include_delta, include_health) and
+      what each attaches to a mutating command's result
+    """
+    rhino = get_rhino_connection()
+    return rhino.send_command("describe_capabilities", {})

--- a/server/src/rhinomcp/validation.py
+++ b/server/src/rhinomcp/validation.py
@@ -185,6 +185,7 @@ def validate_response(command_type: str, response: Dict[str, Any], raise_on_erro
         "get_or_set_current_layer": "layer_info.json",
         "execute_rhinoscript_python_code": "execute_script_result.json",
         "capture_viewport": "capture_viewport_result.json",
+        "describe_capabilities": "capabilities.json",
     }
 
     schema_name = response_schema_map.get(command_type)

--- a/server/tests/mock_rhino_server.py
+++ b/server/tests/mock_rhino_server.py
@@ -206,6 +206,7 @@ class MockRhinoServer:
             "boolean_intersection": self._boolean_intersection,
             "run_command": self._run_command,
             "get_commands": self._get_commands,
+            "describe_capabilities": self._describe_capabilities,
             "execute_rhinoscript_python_code": self._execute_script,
             "execute_rhinocommon_csharp_code": self._execute_csharp,
             "capture_viewport": self._capture_viewport,
@@ -990,6 +991,29 @@ class MockRhinoServer:
             matched = list(all_commands)
         matched.sort(key=str.lower)
         return {"count": len(matched), "commands": matched}
+
+    def _describe_capabilities(self, params: Dict) -> Dict:
+        """Representative capabilities shape. The real plugin reflects its live
+        dispatch table; the mock returns a fixed, well-formed sample so the
+        wiring and the response shape can be exercised."""
+        return {
+            "version": "0.0.0-mock",
+            "command_count": 3,
+            "commands": [
+                {"name": "create_object", "read_only": False},
+                {"name": "delete_object", "read_only": False},
+                {"name": "get_document_summary", "read_only": True},
+            ],
+            "perception": {
+                "description": "Mutating commands accept opt-in envelope flags.",
+                "envelope_flags": [
+                    {"flag": "include_delta", "attaches": "_delta",
+                     "description": "Attaches a change-delta to a mutating command's result."},
+                    {"flag": "include_health", "attaches": "_health",
+                     "description": "Attaches a geometry-health report to a mutating command's result."},
+                ],
+            },
+        }
 
 
 if __name__ == "__main__":

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -908,3 +908,43 @@ class TestMeasureObjects:
         assert result["bbox_gap"] >= 0
         assert result["method"] in ("brep", "curve", "bbox")
         assert result["intersection_count"] >= 0
+
+
+class TestDescribeCapabilities:
+    """End-to-end describe_capabilities through the mock: the server's
+    self-description arrives with the command surface, read-only flags, and
+    perception envelope flags intact."""
+
+    def test_describe_capabilities_shape(self, mock_server):
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+        srv._rhino_connection = None
+
+        conn = get_rhino_connection()
+        result = conn.send_command("describe_capabilities", {})
+
+        assert isinstance(result["version"], str)
+        assert result["command_count"] == len(result["commands"])
+        for c in result["commands"]:
+            assert isinstance(c["name"], str)
+            assert isinstance(c["read_only"], bool)
+        flags = [f["flag"] for f in result["perception"]["envelope_flags"]]
+        assert "include_delta" in flags
+        assert "include_health" in flags
+
+    def test_describe_capabilities_is_readonly_no_delta(self, mock_server):
+        """A read-only command carries no _delta even with perception on."""
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        srv._rhino_connection = None
+        srv.RHINO_PERCEPTION = True
+        try:
+            conn = get_rhino_connection()
+            result = conn.send_command("describe_capabilities", {})
+        finally:
+            srv.RHINO_PERCEPTION = original
+            srv._rhino_connection = None
+
+        assert "_delta" not in result

--- a/server/tests/test_tools.py
+++ b/server/tests/test_tools.py
@@ -1434,6 +1434,44 @@ class TestGetCommandsTool:
         assert call_args[0][1]["loaded_only"] is False
 
 
+class TestDescribeCapabilitiesTool:
+    """Tests for describe_capabilities tool (the MCP server's self-description)."""
+
+    @patch('rhinomcp.tools.describe_capabilities.get_rhino_connection')
+    def test_describe_capabilities(self, mock_get_conn):
+        from rhinomcp.tools.describe_capabilities import describe_capabilities
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "version": "0.3.1",
+            "command_count": 2,
+            "commands": [
+                {"name": "create_object", "read_only": False},
+                {"name": "get_objects", "read_only": True},
+            ],
+            "perception": {
+                "description": "Mutating commands accept opt-in envelope flags.",
+                "envelope_flags": [
+                    {"flag": "include_delta", "attaches": "_delta",
+                     "description": "Attaches a change-delta."},
+                    {"flag": "include_health", "attaches": "_health",
+                     "description": "Attaches a geometry-health report."},
+                ],
+            },
+        }
+        mock_get_conn.return_value = mock_conn
+
+        result = describe_capabilities(ctx=None)
+
+        # Forwards the right command with no params, and returns the surface.
+        assert mock_conn.send_command.call_args[0][0] == "describe_capabilities"
+        assert result["command_count"] == 2
+        assert {"name": "get_objects", "read_only": True} in result["commands"]
+        flags = [f["flag"] for f in result["perception"]["envelope_flags"]]
+        assert "include_delta" in flags
+        assert "include_health" in flags
+
+
 class TestExecutionSafetyGates:
     """The arbitrary-code execution tools must refuse calls when their
     env flag is off, before reaching Rhino."""
@@ -1988,6 +2026,7 @@ class TestToolAnnotations:
             "tools/analyze_objects.py",
             "tools/get_selected_objects_info.py",
             "tools/get_commands.py",
+            "tools/describe_capabilities.py",
             "tools/rhinoscript_docs.py",
             "tools/grasshopper_catalog.py",
             "tools/grasshopper_components.py",


### PR DESCRIPTION
This is the last step of the perception arc. The earlier stages let an agent see what it changed and whether the result is sound; this one lets it see what it can do in the first place. Right now there is no way to ask the server what it actually supports. get_commands looks like it would answer that, but it lists Rhino's own application commands (Box, Circle, ...) for run_command, not the MCP command surface, so an agent that wants to know "what can I send here" has to guess from the tool list or hardcode names.

describe_capabilities answers it directly:

```
{
  "version": "0.3.1",
  "command_count": 64,
  "commands": [ { "name": "create_object", "read_only": false }, { "name": "get_objects", "read_only": true }, ... ],
  "perception": {
    "description": "Mutating commands accept opt-in envelope flags ...",
    "envelope_flags": [
      { "flag": "include_delta", "attaches": "_delta", "description": "..." },
      { "flag": "include_health", "attaches": "_health", "description": "..." }
    ]
  }
}
```

The command list comes straight from the live dispatch table (GetDispatchTable), the same reflection that routes every command, so it can't drift from what the server actually accepts: add a [McpCommand] and it shows up here, with its read-only flag, automatically. The read_only flag is the useful part beyond the names, since it tells the caller which commands mutate the document and which are safe to call freely.

I left parameters out on purpose. The handlers take an untyped JObject, so there is no parameter schema to reflect at runtime, and I would rather return the authoritative command list than half-reflect parameter shapes that already live in the contracts and are surfaced to clients through the MCP tool list. Same reasoning as leaving a modified count off the change-delta: a half-covered field is worse than a clean one.

The perception block advertises the opt-in envelope flags the dispatcher honors. After the rebase onto current main that is both include_delta and include_health, which matches what the dispatcher and the Python server actually send when perception is on. Each entry names the block it attaches (_delta / _health) so the self-description is truthful about the whole envelope. describe_capabilities is itself read-only, so no undo record and no _delta of its own.

Testing:
- pytest in server/, 183 passing. New: end to end through the mock the self-description arrives with the command surface, read-only flags, and both perception flags intact, and a read-only command carries no _delta even with perception on.
- python contracts/test_schemas.py passing, with a capabilities response schema and negatives (a command missing read_only, read_only not a boolean, unknown fields, missing perception, an envelope flag missing its attaches all rejected). The cross-tier sync check confirms protocol.json, the Python wrapper, and the C# handler agree on the new command.
- dotnet build Release clean, with an MCPTestCommand case that calls the handler and asserts the reflected list includes describe_capabilities itself (read-only), create_object (not read-only), and get_document_summary (read-only), with a version and both the include_delta and include_health flags.
- verified against live Rhino 8: under strict response validation the result validates against capabilities.json, version comes back "0.3.1", the list has all 64 commands sorted with no duplicates, the read-only flags match, and perception advertises both include_delta and include_health.

The C# is a small DescribeCapabilities.cs that walks the dispatch table plus a helper for the version. Happy to rename the block, change the shape, or fold parameter info in if you would rather have it.
