### PR TITLE
Count active objects, not the undoable-deleted table count, in document counts

### DIFF
--- a/plugin/Functions/CaptureViewport.cs
+++ b/plugin/Functions/CaptureViewport.cs
@@ -80,8 +80,10 @@ public partial class RhinoMCPFunctions
             // Store viewport name
             string viewportName = targetView.ActiveViewport.Name ?? viewportTarget;
 
-            // Apply zoom to fit if requested
-            if (zoomToFit && doc.Objects.Count > 0)
+            // Apply zoom to fit if requested. Count active objects, not
+            // doc.Objects.Count, which also counts undoable-deleted entries.
+            int activeCount = CountActiveObjects(doc);
+            if (zoomToFit && activeCount > 0)
             {
                 targetView.ActiveViewport.ZoomExtents();
                 doc.Views.Redraw();
@@ -109,7 +111,7 @@ public partial class RhinoMCPFunctions
                 ["show_grid"] = showGrid,
                 ["show_axes"] = showAxes,
                 ["show_cplane_axes"] = showCplaneAxes,
-                ["object_count"] = doc.Objects.Count
+                ["object_count"] = activeCount
             };
         }
         finally

--- a/plugin/Functions/DeleteObject.cs
+++ b/plugin/Functions/DeleteObject.cs
@@ -23,7 +23,7 @@ public partial class RhinoMCPFunctions
 
         if (all)
         {
-            int count = doc.Objects.Count;
+            int count = CountActiveObjects(doc);
             doc.Objects.Clear();
             doc.Views.Redraw();
             return new JObject()

--- a/plugin/Functions/GetDocumentSummary.cs
+++ b/plugin/Functions/GetDocumentSummary.cs
@@ -32,9 +32,15 @@ public partial class RhinoMCPFunctions
         var typeCounts = new Dictionary<string, int>();
         var layerCounts = new Dictionary<int, int>(); // Use layer index for counting
         BoundingBox modelBbox = BoundingBox.Empty;
+        // Count active objects from this same enumeration so object_count always
+        // matches objects_by_type. RhinoObjectTable.Count is avoided: it also
+        // counts objects deleted but still undoable, which over-reports.
+        int objectCount = 0;
 
         foreach (var obj in doc.Objects)
         {
+            objectCount++;
+
             // Count by type
             string objType = GetNormalizedType(obj);
             if (!typeCounts.ContainsKey(objType))
@@ -73,7 +79,7 @@ public partial class RhinoMCPFunctions
         var result = new JObject
         {
             ["meta_data"] = metaData,
-            ["object_count"] = doc.Objects.Count,
+            ["object_count"] = objectCount,
             ["objects_by_type"] = typeCountsJson,
             ["objects_by_layer"] = layerCountsJson,
             ["model_bounding_box"] = modelBbox.IsValid ? Serializer.SerializeBBox(modelBbox) : null,
@@ -81,7 +87,7 @@ public partial class RhinoMCPFunctions
             ["layer_hierarchy"] = layerHierarchy
         };
 
-        RhinoApp.WriteLine($"Document summary collected: {doc.Objects.Count} objects");
+        RhinoApp.WriteLine($"Document summary collected: {objectCount} objects");
         return result;
     }
 

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -1055,6 +1055,43 @@ public partial class RhinoMCPFunctions
             results["modify_object_no_shear"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
         }
 
+        // Test: get_document_summary.object_count reports active objects only, so
+        // it equals objects_by_type and is not inflated by undoable-deleted
+        // entries. Create three, delete one (leaving a tombstone), and check.
+        try
+        {
+            var beforeSummary = GetDocumentSummary(new JObject());
+            int beforeCount = (int)beforeSummary["object_count"];
+            var countIds = new string[3];
+            for (int i = 0; i < 3; i++)
+            {
+                var o = CreateObject(new JObject
+                {
+                    ["type"] = "BOX",
+                    ["name"] = "MCPCountProbe" + i,
+                    ["params"] = new JObject { ["width"] = 1, ["length"] = 1, ["height"] = 1 }
+                });
+                countIds[i] = o["id"]?.ToString();
+            }
+            DeleteObject(new JObject { ["id"] = countIds[0] });   // leaves an undoable tombstone
+            var afterSummary = GetDocumentSummary(new JObject());
+            int afterCount = (int)afterSummary["object_count"];
+            int typeSum = 0;
+            foreach (var kv in (JObject)afterSummary["objects_by_type"]) typeSum += (int)kv.Value;
+            DeleteObject(new JObject { ["id"] = countIds[1] });
+            DeleteObject(new JObject { ["id"] = countIds[2] });
+            if (afterCount != typeSum)
+                throw new Exception("object_count " + afterCount + " != objects_by_type sum " + typeSum);
+            if (afterCount != beforeCount + 2)
+                throw new Exception("object_count net change wrong: " + beforeCount + " -> " + afterCount);
+            results["live_object_count"] = new JObject { ["status"] = "pass", ["count"] = afterCount };
+            VisualUpdate("object_count counts active objects, matches breakdown");
+        }
+        catch (Exception e)
+        {
+            results["live_object_count"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
         // Cleanup
         if (!visualMode)
         {
@@ -1082,6 +1119,9 @@ public partial class RhinoMCPFunctions
                 DeleteObject(new JObject { ["name"] = "MCPMeasureBig" });
                 DeleteObject(new JObject { ["name"] = "MCPMeasureSmall" });
                 DeleteObject(new JObject { ["name"] = "MCPShearBox" });
+                DeleteObject(new JObject { ["name"] = "MCPCountProbe0" });
+                DeleteObject(new JObject { ["name"] = "MCPCountProbe1" });
+                DeleteObject(new JObject { ["name"] = "MCPCountProbe2" });
             }
             catch
             {

--- a/plugin/Functions/_utils.cs
+++ b/plugin/Functions/_utils.cs
@@ -117,6 +117,20 @@ public partial class RhinoMCPFunctions
         throw new InvalidOperationException("Object lookup requires 'id' or 'name'.");
     }
 
+    /// <summary>
+    /// Count the active (non-deleted) objects in the document. This walks the
+    /// same object enumeration get_document_summary categorizes, so the count
+    /// always agrees with that breakdown. RhinoObjectTable.Count is deliberately
+    /// not used: it also counts objects that were deleted but are still undoable,
+    /// so it over-reports until the undo history is cleared.
+    /// </summary>
+    private int CountActiveObjects(RhinoDoc doc)
+    {
+        int count = 0;
+        foreach (var obj in doc.Objects) count++;
+        return count;
+    }
+
     private Transform applyRotation(JObject parameters, GeometryBase geometry)
     {
         double[] rotation = parameters["rotation"].ToObject<double[]>();


### PR DESCRIPTION
`get_document_summary` can report an `object_count` that is higher than the
document actually has, and that disagrees with its own `objects_by_type`
breakdown.

The summary builds `objects_by_type` and `objects_by_layer` by walking
`doc.Objects` (the active objects), but it takes the headline `object_count` from
`doc.Objects.Count`. Those are not the same set: `RhinoObjectTable.Count` also
counts objects that were deleted but are still undoable, so after any deletion the
count stays inflated until the undo history clears (usually on save). You end up
with `object_count: 5` sitting next to an `objects_by_type` that sums to 3.

I hit this driving the bridge: create five objects, delete two, ask for the
summary, and it says five. `get_objects`, which walks the active set, says three.
Same document, two answers.

The fix is to count what we actually enumerate. I added a small
`CountActiveObjects(doc)` helper that walks `doc.Objects`, and used it everywhere
a count goes back to the client:

- `get_document_summary` takes `object_count` from the same loop that builds the
  breakdown, so the two can't disagree.
- `capture_viewport` reports its `object_count` and decides zoom-to-fit from the
  active count.
- `delete_object`'s all-scope reports how many active objects it actually cleared.

I deliberately left the undo/tombstone behavior alone. Those entries are what make
a deletion undoable, which is correct; the bug was only in how we counted.

Verified live over the bridge: create five, delete two, and `object_count` comes
back three, matching both `objects_by_type` and `get_objects`, while the raw table
count is still five. There is an `mcptest` case that creates a few objects,
deletes one, and asserts `object_count` equals the `objects_by_type` sum.
`dotnet build` Release is clean and the existing pytest and schema suites pass.
The mock server already counts active objects this way, so this also brings the
plugin in line with the mock.
