### PR TITLE
Strip the perception envelope keys before response validation

### DIFF
--- a/server/src/rhinomcp/server.py
+++ b/server/src/rhinomcp/server.py
@@ -41,6 +41,11 @@ RHINO_PERCEPTION = os.getenv("RHINO_MCP_PERCEPTION", "").lower() in (
     "yes",
     "on",
 )
+# Envelope metadata the plugin injects into a mutating command's result when
+# perception is on. These are cross-cutting, not part of any single command's
+# result contract, so they are stripped before post-flight validation; the
+# full result, these keys included, is still returned to the caller.
+PERCEPTION_RESULT_KEYS = ("_delta", "_health")
 RHINO_DEBUG = os.getenv("RHINO_MCP_DEBUG", "").lower() in ("1", "true", "yes")
 RHINO_LOG_LEVEL = os.getenv("RHINO_MCP_LOG_LEVEL", "DEBUG" if RHINO_DEBUG else "INFO")
 # Pre-flight schema validation. Three modes:
@@ -333,8 +338,23 @@ class RhinoConnection:
             if RHINO_VALIDATE != "off":
                 from rhinomcp.validation import HAS_JSONSCHEMA, validate_response
 
+                # Validate the command's own result, not the perception envelope
+                # the plugin may have injected into it. _delta / _health are
+                # metadata no response schema declares, so leaving them in would
+                # trip a closed (additionalProperties:false) schema such as
+                # object_attributes and fail an otherwise-correct response.
+                to_validate = result
+                if isinstance(result, dict) and any(
+                    key in result for key in PERCEPTION_RESULT_KEYS
+                ):
+                    to_validate = {
+                        key: value
+                        for key, value in result.items()
+                        if key not in PERCEPTION_RESULT_KEYS
+                    }
+
                 try:
-                    validate_response(command_type, result, raise_on_error=True)
+                    validate_response(command_type, to_validate, raise_on_error=True)
                 except Exception as ve:
                     # Only a genuine validation verdict gets the warn/strict
                     # treatment. Anything else (unresolvable $ref, unreadable

--- a/server/tests/test_connection.py
+++ b/server/tests/test_connection.py
@@ -470,6 +470,74 @@ class TestResponseValidation:
             for r in caplog.records
         )
 
+    # A result that satisfies the closed responses/object_attributes.json
+    # (additionalProperties:false), used to prove perception keys are stripped
+    # before validation rather than rejected by it.
+    VALID_OBJECT_ATTRIBUTES = {
+        "id": "12345678-1234-1234-1234-123456789012",
+        "name": "MyBox",
+        "type": "BOX",
+        "layer": {
+            "index": 0,
+            "id": "12345678-1234-1234-1234-123456789012",
+            "name": "Default",
+            "full_path": "Default",
+        },
+        "color": {"r": 255, "g": 0, "b": 0},
+        "color_source": "by_layer",
+        "material_index": -1,
+        "material_source": "by_layer",
+        "visible": True,
+        "locked": False,
+        "hidden": False,
+        "normal": True,
+        "user_strings": {},
+    }
+
+    @patch("socket.socket")
+    def test_perception_keys_do_not_fail_closed_schema(self, mock_socket_class):
+        """With perception on, the plugin injects _delta/_health into a mutating
+        command's result. object_attributes.json is closed, so validating the
+        raw result would reject those keys and turn a successful
+        update_object_attributes into a strict-mode error. They must be stripped
+        before validation, and still come back to the caller."""
+        import rhinomcp.server as srv
+
+        result_with_perception = {
+            **self.VALID_OBJECT_ATTRIBUTES,
+            "_delta": {
+                "created_ids": [],
+                "deleted_ids": [],
+                "count_before": 1,
+                "count_after": 1,
+            },
+            "_health": {
+                "checked_count": 0,
+                "invalid_count": 0,
+                "issues": [],
+                "truncated": False,
+            },
+        }
+        conn = self._connect_with_response(
+            mock_socket_class, result_with_perception
+        )
+
+        original_mode = srv.RHINO_VALIDATE
+        srv.RHINO_VALIDATE = "strict"
+        try:
+            result = conn.send_command(
+                "update_object_attributes",
+                {"id": "12345678-1234-1234-1234-123456789012", "visible": True},
+            )
+        finally:
+            srv.RHINO_VALIDATE = original_mode
+
+        # No raise in strict mode, and the perception blocks survive untouched
+        # in the returned result.
+        assert result["name"] == "MyBox"
+        assert result["_delta"]["count_after"] == 1
+        assert result["_health"]["invalid_count"] == 0
+
 
 class TestPerceptionForwarding:
     """Opt-in perception forwards an envelope-level include_delta flag and


### PR DESCRIPTION
I hit this running both `RHINO_MCP_PERCEPTION` and `RHINO_MCP_VALIDATE=strict`
at the same time: a successful `update_object_attributes` came back to the client
as an error.

The cause is an interaction between perception and the post-flight response
check. When perception is on, the plugin injects `_delta` (and `_health`) into
the result of a mutating command. The Python side then validates that result
against the command's response schema. `object_attributes.json` is closed
(`additionalProperties: false`), so the injected `_delta`/`_health` are rejected
and a command that actually ran in Rhino surfaces as a contract-validation
failure. In the default `warn` mode it is quieter but still wrong: it logs a
validation error on every such call, which is exactly the noise that erodes
trust in the validation signal.

The fix is small. `_delta`/`_health` are envelope metadata, not part of any
single command's result contract, so I strip them from the copy that gets
validated. The full result, those keys included, is still returned to the
caller. This mirrors the request side, which keeps the perception flags on the
envelope and off `params`.

Today `update_object_attributes` is the only mutating command mapped to a closed
response schema, so it is the only one that trips this right now. But any future
mutating command mapped to a closed schema would inherit the same false failure,
so the right place to fix it is the validation boundary, once, rather than per
schema.

Testing:
- New test: a mutating command whose result carries `_delta`/`_health` passes
  strict validation, and the perception blocks still come back to the caller. I
  confirmed it fails without the strip (the raw result is rejected for the
  unexpected `_delta`/`_health`) and passes with it.
- `pytest` green; `contracts/test_schemas.py` green.

Python only, no plugin change. Default behavior is unchanged: with validation in
its default `warn` mode, or perception off, responses are byte-identical to
before.
