### PR TITLE
Make boolean operations reject non-brep inputs instead of silently deleting them

### DIFF
--- a/plugin/Functions/BooleanOperations.cs
+++ b/plugin/Functions/BooleanOperations.cs
@@ -36,8 +36,9 @@ public partial class RhinoMCPFunctions
 
             sourceObjects.Add(obj);
             var brep = GetBrepFromObject(obj);
-            if (brep != null)
-                breps.Add(brep);
+            if (brep == null)
+                throw new InvalidOperationException($"Object {idStr} is not a solid, surface, or extrusion and cannot be used in a boolean operation");
+            breps.Add(brep);
         }
 
         if (breps.Count < 2)
@@ -117,8 +118,9 @@ public partial class RhinoMCPFunctions
 
             subtractObjects.Add(obj);
             var brep = GetBrepFromObject(obj);
-            if (brep != null)
-                subtractBreps.Add(brep);
+            if (brep == null)
+                throw new InvalidOperationException($"Object {idStr} is not a solid, surface, or extrusion and cannot be used in a boolean operation");
+            subtractBreps.Add(brep);
         }
 
         if (subtractBreps.Count == 0)
@@ -184,8 +186,9 @@ public partial class RhinoMCPFunctions
 
             sourceObjects.Add(obj);
             var brep = GetBrepFromObject(obj);
-            if (brep != null)
-                breps.Add(brep);
+            if (brep == null)
+                throw new InvalidOperationException($"Object {idStr} is not a solid, surface, or extrusion and cannot be used in a boolean operation");
+            breps.Add(brep);
         }
 
         if (breps.Count < 2)

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -1294,6 +1294,205 @@ public partial class RhinoMCPFunctions
             results["section_profile"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
         }
 
+        // Test: boolean_union must reject a non-brep input instead of silently
+        // deleting it. Two overlapping boxes plus a line: the union appended
+        // every input to the delete list before extracting a brep, so under the
+        // default delete_sources it destroyed the line. It must now throw and
+        // leave all three inputs in the document.
+        try
+        {
+            var pos = visualMode ? GetNextPosition() : new JArray { 170, 0, 0 };
+            var ub1 = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPBoolRejectUnionBox1",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = pos
+            });
+            var pos2 = new JArray { ((JArray)pos)[0].ToObject<double>() + 5, ((JArray)pos)[1].ToObject<double>(), 0 };
+            var ub2 = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPBoolRejectUnionBox2",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = pos2
+            });
+            var uLine = CreateObject(new JObject
+            {
+                ["type"] = "LINE",
+                ["name"] = "MCPBoolRejectUnionLine",
+                ["params"] = new JObject { ["start"] = new JArray { 0, 0, 0 }, ["end"] = new JArray { 10, 10, 0 } },
+                ["translation"] = pos
+            });
+            string ub1Id = ub1["id"]?.ToString();
+            string ub2Id = ub2["id"]?.ToString();
+            string uLineId = uLine["id"]?.ToString();
+
+            bool threw = false;
+            try
+            {
+                BooleanUnion(new JObject
+                {
+                    ["object_ids"] = new JArray { ub1Id, ub2Id, uLineId },
+                    ["delete_sources"] = true
+                });
+            }
+            catch (Exception)
+            {
+                threw = true;
+            }
+
+            bool allResolve = doc.Objects.Find(new Guid(ub1Id)) != null
+                && doc.Objects.Find(new Guid(ub2Id)) != null
+                && doc.Objects.Find(new Guid(uLineId)) != null;
+
+            DeleteObject(new JObject { ["id"] = ub1Id });
+            DeleteObject(new JObject { ["id"] = ub2Id });
+            DeleteObject(new JObject { ["id"] = uLineId });
+
+            if (!threw)
+                throw new Exception("boolean_union accepted a non-brep input instead of throwing");
+            if (!allResolve)
+                throw new Exception("boolean_union deleted an input after rejecting a non-brep");
+            results["boolean_union_rejects_non_brep"] = new JObject { ["status"] = "pass" };
+            VisualUpdate("boolean_union rejects a non-brep and deletes nothing");
+        }
+        catch (Exception e)
+        {
+            results["boolean_union_rejects_non_brep"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
+        // Test: boolean_difference must reject a non-brep in subtract_ids the
+        // same way, leaving the base and both subtract inputs in the document.
+        try
+        {
+            var pos = visualMode ? GetNextPosition() : new JArray { 190, 0, 0 };
+            var dBase = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPBoolRejectDiffBase",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = pos
+            });
+            var pos2 = new JArray { ((JArray)pos)[0].ToObject<double>() + 5, ((JArray)pos)[1].ToObject<double>(), 0 };
+            var dSub = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPBoolRejectDiffSub",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = pos2
+            });
+            var dLine = CreateObject(new JObject
+            {
+                ["type"] = "LINE",
+                ["name"] = "MCPBoolRejectDiffLine",
+                ["params"] = new JObject { ["start"] = new JArray { 0, 0, 0 }, ["end"] = new JArray { 10, 10, 0 } },
+                ["translation"] = pos
+            });
+            string dBaseId = dBase["id"]?.ToString();
+            string dSubId = dSub["id"]?.ToString();
+            string dLineId = dLine["id"]?.ToString();
+
+            bool threw = false;
+            try
+            {
+                BooleanDifference(new JObject
+                {
+                    ["base_id"] = dBaseId,
+                    ["subtract_ids"] = new JArray { dSubId, dLineId },
+                    ["delete_sources"] = true
+                });
+            }
+            catch (Exception)
+            {
+                threw = true;
+            }
+
+            bool allResolve = doc.Objects.Find(new Guid(dBaseId)) != null
+                && doc.Objects.Find(new Guid(dSubId)) != null
+                && doc.Objects.Find(new Guid(dLineId)) != null;
+
+            DeleteObject(new JObject { ["id"] = dBaseId });
+            DeleteObject(new JObject { ["id"] = dSubId });
+            DeleteObject(new JObject { ["id"] = dLineId });
+
+            if (!threw)
+                throw new Exception("boolean_difference accepted a non-brep subtract input instead of throwing");
+            if (!allResolve)
+                throw new Exception("boolean_difference deleted an input after rejecting a non-brep");
+            results["boolean_difference_rejects_non_brep"] = new JObject { ["status"] = "pass" };
+            VisualUpdate("boolean_difference rejects a non-brep and deletes nothing");
+        }
+        catch (Exception e)
+        {
+            results["boolean_difference_rejects_non_brep"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
+        // Test: boolean_intersection must reject a non-brep input the same way,
+        // leaving both boxes and the line in the document.
+        try
+        {
+            var pos = visualMode ? GetNextPosition() : new JArray { 210, 0, 0 };
+            var ib1 = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPBoolRejectIntBox1",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = pos
+            });
+            var pos2 = new JArray { ((JArray)pos)[0].ToObject<double>() + 5, ((JArray)pos)[1].ToObject<double>(), 0 };
+            var ib2 = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPBoolRejectIntBox2",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = pos2
+            });
+            var iLine = CreateObject(new JObject
+            {
+                ["type"] = "LINE",
+                ["name"] = "MCPBoolRejectIntLine",
+                ["params"] = new JObject { ["start"] = new JArray { 0, 0, 0 }, ["end"] = new JArray { 10, 10, 0 } },
+                ["translation"] = pos
+            });
+            string ib1Id = ib1["id"]?.ToString();
+            string ib2Id = ib2["id"]?.ToString();
+            string iLineId = iLine["id"]?.ToString();
+
+            bool threw = false;
+            try
+            {
+                BooleanIntersection(new JObject
+                {
+                    ["object_ids"] = new JArray { ib1Id, ib2Id, iLineId },
+                    ["delete_sources"] = true
+                });
+            }
+            catch (Exception)
+            {
+                threw = true;
+            }
+
+            bool allResolve = doc.Objects.Find(new Guid(ib1Id)) != null
+                && doc.Objects.Find(new Guid(ib2Id)) != null
+                && doc.Objects.Find(new Guid(iLineId)) != null;
+
+            DeleteObject(new JObject { ["id"] = ib1Id });
+            DeleteObject(new JObject { ["id"] = ib2Id });
+            DeleteObject(new JObject { ["id"] = iLineId });
+
+            if (!threw)
+                throw new Exception("boolean_intersection accepted a non-brep input instead of throwing");
+            if (!allResolve)
+                throw new Exception("boolean_intersection deleted an input after rejecting a non-brep");
+            results["boolean_intersection_rejects_non_brep"] = new JObject { ["status"] = "pass" };
+            VisualUpdate("boolean_intersection rejects a non-brep and deletes nothing");
+        }
+        catch (Exception e)
+        {
+            results["boolean_intersection_rejects_non_brep"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
         // Cleanup
         if (!visualMode)
         {
@@ -1329,6 +1528,15 @@ public partial class RhinoMCPFunctions
                 DeleteObject(new JObject { ["name"] = "MCPSectionSurface" });
                 DeleteObject(new JObject { ["name"] = "MCPSectTubeBig" });
                 DeleteObject(new JObject { ["name"] = "MCPSectTubeSmall" });
+                DeleteObject(new JObject { ["name"] = "MCPBoolRejectUnionBox1" });
+                DeleteObject(new JObject { ["name"] = "MCPBoolRejectUnionBox2" });
+                DeleteObject(new JObject { ["name"] = "MCPBoolRejectUnionLine" });
+                DeleteObject(new JObject { ["name"] = "MCPBoolRejectDiffBase" });
+                DeleteObject(new JObject { ["name"] = "MCPBoolRejectDiffSub" });
+                DeleteObject(new JObject { ["name"] = "MCPBoolRejectDiffLine" });
+                DeleteObject(new JObject { ["name"] = "MCPBoolRejectIntBox1" });
+                DeleteObject(new JObject { ["name"] = "MCPBoolRejectIntBox2" });
+                DeleteObject(new JObject { ["name"] = "MCPBoolRejectIntLine" });
             }
             catch
             {


### PR DESCRIPTION
**The bug.** All three boolean handlers track every resolved input for deletion before checking whether it can participate. `GetBrepFromObject` returns null for anything that is not a Brep/Extrusion/Surface (mesh, curve, point), and the loop silently skips those, but they stay in the source list. With `delete_sources` true (the default), the delete loop then removes them even though they never entered the operation. Reproduced live on Rhino 8: `boolean_union` of two overlapping boxes plus a mesh returns "Boolean union created 1 object(s)" and the mesh is gone. The deletion happens inside the command's undo record, so a user can recover with undo, but the response gives no hint anything beyond the union happened.

**The boundary.** The bug only bites when enough valid breps remain to pass the count guard. `[box, mesh]` already throws before any mutation; `[box, box, mesh]` proceeds and deletes the mesh. The base object in `boolean_difference` was already safe (it throws if it yields no brep).

**The fix.** Fail closed, before any mutation: if a resolved input yields no brep, throw `Object {id} is not a solid, surface, or extrusion and cannot be used in a boolean operation`. This matches how the other generative handlers already treat wrong-typed inputs (`loft`, `sweep1`, `offset_curve` and `extrude_curve` all throw "Object {id} is not a curve" style errors up front); the booleans were the one place a wrong-typed input was tolerated and then destroyed. I preferred rejecting the call over silently operating on the subset, since dropping a named input from a boolean is exactly the kind of surprise the other handlers avoid, and the caller can simply resend without the offending id. Count guards stay as they were.

**Tests.** Three new mcptest regression cases (`boolean_union_rejects_non_brep`, `boolean_difference_rejects_non_brep`, `boolean_intersection_rejects_non_brep`), each built so the old code would have passed the count guard and deleted the line: two participating boxes plus a LINE, assert the handler throws, assert all three inputs still resolve afterward, self-clean. Verified end to end on a deployed build in live Rhino 8: the pre-fix plugin silently deleted the mesh, the fixed plugin returns the error above and deletes nothing, and a plain two-box union still works. Full TestAllFunctions run on the fixed build: the three new cases pass and all other cases behave as on stock 0.3.2. One pre-existing failure unrelated to this change showed up in that run: `modify_object_no_shear` casts the modified object to Brep, but on my Rhino the box comes back as an Extrusion, so the check bails; this diff never touches that path (my additions are purely additive after the existing cases). Happy to send a separate small fix for that test if useful. dotnet Release build clean (0 warnings). Server pytest suite (193) and `contracts/test_schemas.py` all pass unchanged; no Python or schema files are touched.