### PR TITLE
Add a dry_run preview to the boolean commands

### DIFF
--- a/contracts/commands/boolean_difference.json
+++ b/contracts/commands/boolean_difference.json
@@ -14,7 +14,12 @@
       "description": "GUIDs of solids to subtract"
     },
     "delete_sources": { "type": "boolean", "default": true },
-    "name": { "type": "string" }
+    "name": { "type": "string" },
+    "dry_run": {
+      "type": "boolean",
+      "default": false,
+      "description": "Preview the result and its metrics without modifying the document"
+    }
   },
   "required": ["base_id", "subtract_ids"],
   "additionalProperties": false

--- a/contracts/commands/boolean_intersection.json
+++ b/contracts/commands/boolean_intersection.json
@@ -13,7 +13,12 @@
       "description": "GUIDs of solids to intersect (at least 2)"
     },
     "delete_sources": { "type": "boolean", "default": true },
-    "name": { "type": "string" }
+    "name": { "type": "string" },
+    "dry_run": {
+      "type": "boolean",
+      "default": false,
+      "description": "Preview the result and its metrics without modifying the document"
+    }
   },
   "required": ["object_ids"],
   "additionalProperties": false

--- a/contracts/commands/boolean_union.json
+++ b/contracts/commands/boolean_union.json
@@ -13,7 +13,12 @@
       "description": "GUIDs of solids to union (at least 2)"
     },
     "delete_sources": { "type": "boolean", "default": true },
-    "name": { "type": "string" }
+    "name": { "type": "string" },
+    "dry_run": {
+      "type": "boolean",
+      "default": false,
+      "description": "Preview the result and its metrics without modifying the document"
+    }
   },
   "required": ["object_ids"],
   "additionalProperties": false

--- a/contracts/responses/boolean_result.json
+++ b/contracts/responses/boolean_result.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "boolean_result.json",
+  "title": "BooleanOperation Response",
+  "description": "Result of a boolean union, difference, or intersection: either the committed objects, or, for a dry_run, the metrics a real run would produce with no document change.",
+  "oneOf": [
+    {
+      "type": "object",
+      "description": "Committed result: the ids of the objects the operation created.",
+      "properties": {
+        "result_ids": { "$ref": "../common/definitions.json#/$defs/guidArray" },
+        "count": { "type": "integer", "minimum": 0 },
+        "message": { "type": "string" }
+      },
+      "required": ["result_ids", "count", "message"],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "description": "Dry_run preview: the predicted result metrics, with nothing added to or removed from the document.",
+      "properties": {
+        "dry_run": { "const": true },
+        "would_succeed": { "type": "boolean" },
+        "count": { "type": "integer", "minimum": 0 },
+        "results": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "valid": { "type": "boolean" },
+              "reason": { "type": "string" },
+              "is_solid": { "type": "boolean" },
+              "volume": { "type": "number" },
+              "area": { "type": "number" },
+              "bounding_box": { "$ref": "../common/definitions.json#/$defs/boundingBox" }
+            },
+            "required": ["valid", "is_solid", "bounding_box"],
+            "additionalProperties": false
+          }
+        },
+        "message": { "type": "string" }
+      },
+      "required": ["dry_run", "would_succeed", "count", "results", "message"],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/responses/capabilities.json
+++ b/contracts/responses/capabilities.json
@@ -27,6 +27,10 @@
           "read_only": {
             "type": "boolean",
             "description": "True if the command does not mutate the document (no undo record)."
+          },
+          "supports_dry_run": {
+            "type": "boolean",
+            "description": "True if the command honors a dry_run preview. Optional: a plugin from before dry_run existed omits it, and a client must read absent as false rather than assume support."
           }
         },
         "required": ["name", "read_only"],

--- a/contracts/test_schemas.py
+++ b/contracts/test_schemas.py
@@ -457,10 +457,11 @@ def test_responses():
     print("  capabilities:")
     capabilities = {
         "version": "0.3.2",
-        "command_count": 2,
+        "command_count": 3,
         "commands": [
-            {"name": "create_object", "read_only": False},
-            {"name": "get_objects", "read_only": True},
+            {"name": "boolean_union", "read_only": False, "supports_dry_run": True},
+            {"name": "create_object", "read_only": False, "supports_dry_run": False},
+            {"name": "get_objects", "read_only": True, "supports_dry_run": False},
         ],
         "perception": {
             "description": "Mutating commands accept opt-in envelope flags.",
@@ -478,6 +479,17 @@ def test_responses():
                     "perception": {"description": "none", "envelope_flags": []}}
     if not validate("responses/capabilities.json", minimal_caps):
         all_passed = False
+    # supports_dry_run is optional: a plugin older than the flag omits it, and its
+    # answer still has to validate. A client reads absent as false, which is the
+    # same fail-closed verdict the schema's optionality encodes.
+    legacy_caps = {
+        "version": "0.3.1",
+        "command_count": 1,
+        "commands": [{"name": "boolean_union", "read_only": False}],
+        "perception": {"description": "none", "envelope_flags": []},
+    }
+    if not validate("responses/capabilities.json", legacy_caps):
+        all_passed = False
     caps_validator = Draft202012Validator(load_schema_with_refs("responses/capabilities.json"))
     bad_caps = [
         # a command missing read_only
@@ -485,6 +497,10 @@ def test_responses():
          "perception": {"description": "d", "envelope_flags": []}},
         # read_only not a boolean
         {"version": "0.3.2", "command_count": 1, "commands": [{"name": "x", "read_only": "yes"}],
+         "perception": {"description": "d", "envelope_flags": []}},
+        # supports_dry_run not a boolean
+        {"version": "0.3.2", "command_count": 1,
+         "commands": [{"name": "x", "read_only": False, "supports_dry_run": "yes"}],
          "perception": {"description": "d", "envelope_flags": []}},
         # unknown top-level field
         {"version": "0.3.2", "command_count": 0, "commands": [],

--- a/contracts/test_schemas.py
+++ b/contracts/test_schemas.py
@@ -224,6 +224,9 @@ def test_new_commands():
         ("commands/boolean_union.json", {"object_ids": [GUID, GUID]}),
         ("commands/boolean_difference.json", {"base_id": GUID, "subtract_ids": [GUID]}),
         ("commands/boolean_intersection.json", {"object_ids": [GUID, GUID]}),
+        ("commands/boolean_union.json", {"object_ids": [GUID, GUID], "dry_run": True}),
+        ("commands/boolean_difference.json", {"base_id": GUID, "subtract_ids": [GUID], "dry_run": True}),
+        ("commands/boolean_intersection.json", {"object_ids": [GUID, GUID], "dry_run": True}),
         ("commands/create_objects.json", {"Box1": {"type": "BOX", "params": {"width": 1, "length": 1, "height": 1}}}),
         ("commands/execute_rhinocommon_csharp_code.json", {"code": "doc.Objects.AddPoint(0,0,0);"}),
         ("commands/extrude_curve.json", {"curve_id": GUID, "direction": [0, 0, 10]}),
@@ -753,6 +756,61 @@ def test_responses():
             all_passed = False
     print("  section_profile_result negatives correctly rejected")
 
+    # Boolean result: one schema, two shapes discriminated by dry_run.
+    print("  boolean_result:")
+    committed = {
+        "result_ids": ["12345678-1234-1234-1234-123456789012"],
+        "count": 1,
+        "message": "Boolean union created 1 object(s)",
+    }
+    if not validate("responses/boolean_result.json", committed):
+        all_passed = False
+    preview_solid = {
+        "dry_run": True,
+        "would_succeed": True,
+        "count": 1,
+        "results": [
+            {"valid": True, "is_solid": True, "volume": 1500.0, "area": 800.0,
+             "bounding_box": [[0, 0, 0], [15, 10, 10]]}
+        ],
+        "message": "Boolean union would create 1 object(s)",
+    }
+    if not validate("responses/boolean_result.json", preview_solid):
+        all_passed = False
+    # An invalid predicted result carries a reason and, because mass-property
+    # compute can fail on a bad brep, omits both volume and area.
+    preview_invalid = {
+        "dry_run": True,
+        "would_succeed": True,
+        "count": 1,
+        "results": [
+            {"valid": False, "reason": "brep is not manifold", "is_solid": False,
+             "bounding_box": [[0, 0, 0], [1, 1, 1]]}
+        ],
+        "message": "Boolean difference would create 1 object(s)",
+    }
+    if not validate("responses/boolean_result.json", preview_invalid):
+        all_passed = False
+
+    boolean_schema = load_schema_with_refs("responses/boolean_result.json")
+    boolean_validator = Draft202012Validator(boolean_schema)
+    bad_booleans = [
+        {"count": 1, "message": "x"},  # committed shape missing result_ids
+        {"dry_run": True, "count": 1, "results": [], "message": "x"},  # preview missing would_succeed
+        {"dry_run": True, "would_succeed": True, "count": 1, "message": "x",
+         "results": [{"valid": True, "is_solid": True, "area": 1.0,
+                      "volume": "lots", "bounding_box": [[0, 0, 0], [1, 1, 1]]}]},  # volume wrong type
+        {"result_ids": ["12345678-1234-1234-1234-123456789012"], "count": 1,
+         "message": "x", "bogus": 1},  # committed shape unknown field
+        {"dry_run": True, "would_succeed": True, "count": 1, "message": "x",
+         "results": [{"valid": True, "bounding_box": [[0, 0, 0], [1, 1, 1]]}]},  # preview result missing is_solid
+    ]
+    for bad in bad_booleans:
+        if not list(boolean_validator.iter_errors(bad)):
+            print(f"  FAIL: boolean_result accepted invalid payload {bad}")
+            all_passed = False
+    print("  boolean_result negatives correctly rejected")
+
     return all_passed
 
 
@@ -788,6 +846,9 @@ def test_invalid_examples():
         ("commands/create_object.json", {"type": "BOX", "params": {"width": 1, "length": 1, "height": 1}, "bogus": 1}, "create_object unknown top-level field"),
         # New schemas reject obvious mistakes
         ("commands/boolean_union.json", {"object_ids": ["only-one"]}, "boolean_union not enough ids (and bad GUID)"),
+        ("commands/boolean_union.json", {"object_ids": ["12345678-1234-1234-1234-123456789012", "12345678-1234-1234-1234-123456789012"], "dry_run": "yes"}, "boolean_union dry_run not boolean"),
+        ("commands/boolean_difference.json", {"base_id": "12345678-1234-1234-1234-123456789012", "subtract_ids": ["12345678-1234-1234-1234-123456789012"], "dry_run": 1}, "boolean_difference dry_run not boolean"),
+        ("commands/boolean_intersection.json", {"object_ids": ["12345678-1234-1234-1234-123456789012", "12345678-1234-1234-1234-123456789012"], "dry_run": "no"}, "boolean_intersection dry_run not boolean"),
         ("commands/extrude_curve.json", {"curve_id": "12345678-1234-1234-1234-123456789012", "direction": [0, 0, 0]}, "extrude_curve zero direction"),
         ("commands/pipe.json", {"curve_id": "12345678-1234-1234-1234-123456789012", "radius": 0}, "pipe non-positive radius"),
         ("commands/undo.json", {"steps": 0}, "undo zero steps"),

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -285,10 +285,22 @@ invalid result can otherwise land silently. See
 ### Capabilities (Self-Description)
 
 `describe_capabilities` returns what this server itself can do: every command it
-handles with a `read_only` flag, the perception envelope flags it honors, and the
-plugin version. The command list is built from the live dispatch table
-(`GetDispatchTable`), so it can't drift from what the server actually accepts;
-adding a `[McpCommand]` makes it appear automatically.
+handles with a `read_only` and a `supports_dry_run` flag, the perception envelope
+flags it honors, and the plugin version. The command list is built from the live
+dispatch table (`GetDispatchTable`), so it can't drift from what the server
+actually accepts; adding a `[McpCommand]` makes it appear automatically, and both
+flags are read off the same attribute the dispatcher gates on.
+
+The Python server uses that answer as a version gate. Server and plugin ship
+separately, so a server that knows `dry_run` can end up talking to a plugin that
+doesn't: the old plugin drops the flag it has never heard of, runs the real
+boolean and deletes the source objects, while the caller reads the reply as a
+preview. A command carrying `dry_run` is therefore only sent once the plugin has
+advertised `supports_dry_run` for that exact command. The answer is read once per
+connection and cached until the socket drops, and every uncertain case (no
+`describe_capabilities` at all, a failed read, a command the list doesn't
+mention, a missing field) counts as unsupported. Commands without `dry_run` never
+trigger the lookup and are sent exactly as before.
 
 This is deliberately distinct from `get_commands`, which lists Rhino's own
 application commands (`Box`, `Circle`, ...) for use with `run_command`.

--- a/plugin/Functions/BooleanOperations.cs
+++ b/plugin/Functions/BooleanOperations.cs
@@ -14,40 +14,22 @@ public partial class RhinoMCPFunctions
     /// <summary>
     /// Perform a boolean union on multiple objects.
     /// </summary>
-    [McpCommand("boolean_union")]
+    [McpCommand("boolean_union", SupportsDryRun = true)]
     public JObject BooleanUnion(JObject parameters)
     {
-        var doc = RhinoDoc.ActiveDoc;
-        var objectIds = parameters["object_ids"]?.ToObject<List<string>>();
-        var deleteSources = parameters["delete_sources"]?.ToObject<bool>() ?? true;
-        var name = parameters["name"]?.ToString();
+        var results = ComputeBooleanUnion(parameters, out var sourceObjects);
 
-        if (objectIds == null || objectIds.Count < 2)
-            throw new ArgumentException("Boolean union requires at least 2 object IDs");
-
-        var breps = new List<Brep>();
-        var sourceObjects = new List<RhinoObject>();
-
-        foreach (var idStr in objectIds)
+        if (parameters["dry_run"]?.ToObject<bool>() == true)
         {
-            var obj = doc.Objects.Find(new Guid(idStr));
-            if (obj == null)
-                throw new InvalidOperationException($"Object with ID {idStr} not found");
-
-            sourceObjects.Add(obj);
-            var brep = GetBrepFromObject(obj);
-            if (brep == null)
-                throw new InvalidOperationException($"Object {idStr} is not a solid, surface, or extrusion and cannot be used in a boolean operation");
-            breps.Add(brep);
+            var message = $"Boolean union would create {results.Length} object(s)";
+            if (results.Length == sourceObjects.Count)
+                message += "; inputs do not intersect, so nothing would merge";
+            return PredictBoolean(results, message);
         }
 
-        if (breps.Count < 2)
-            throw new InvalidOperationException("Could not extract valid Breps from the provided objects");
-
-        var results = Brep.CreateBooleanUnion(breps, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
-
-        if (results == null || results.Length == 0)
-            throw new InvalidOperationException("Boolean union failed - objects may not intersect or be valid solids");
+        var doc = RhinoDoc.ActiveDoc;
+        var deleteSources = parameters["delete_sources"]?.ToObject<bool>() ?? true;
+        var name = parameters["name"]?.ToString();
 
         // Delete source objects if requested
         if (deleteSources)
@@ -81,55 +63,17 @@ public partial class RhinoMCPFunctions
     /// <summary>
     /// Perform a boolean difference (subtraction) operation.
     /// </summary>
-    [McpCommand("boolean_difference")]
+    [McpCommand("boolean_difference", SupportsDryRun = true)]
     public JObject BooleanDifference(JObject parameters)
     {
+        var results = ComputeBooleanDifference(parameters, out var baseObj, out var subtractObjects);
+
+        if (parameters["dry_run"]?.ToObject<bool>() == true)
+            return PredictBoolean(results, $"Boolean difference would create {results.Length} object(s)");
+
         var doc = RhinoDoc.ActiveDoc;
-        var baseId = parameters["base_id"]?.ToString();
-        var subtractIds = parameters["subtract_ids"]?.ToObject<List<string>>();
         var deleteSources = parameters["delete_sources"]?.ToObject<bool>() ?? true;
         var name = parameters["name"]?.ToString();
-
-        if (string.IsNullOrEmpty(baseId))
-            throw new ArgumentException("Boolean difference requires a base_id");
-
-        if (subtractIds == null || subtractIds.Count == 0)
-            throw new ArgumentException("Boolean difference requires at least one subtract_id");
-
-        var baseObj = doc.Objects.Find(new Guid(baseId));
-        if (baseObj == null)
-            throw new InvalidOperationException($"Base object with ID {baseId} not found");
-
-        var baseBreps = new List<Brep>();
-        var baseBrep = GetBrepFromObject(baseObj);
-        if (baseBrep != null)
-            baseBreps.Add(baseBrep);
-        else
-            throw new InvalidOperationException("Could not extract valid Brep from base object");
-
-        var subtractBreps = new List<Brep>();
-        var subtractObjects = new List<RhinoObject>();
-
-        foreach (var idStr in subtractIds)
-        {
-            var obj = doc.Objects.Find(new Guid(idStr));
-            if (obj == null)
-                throw new InvalidOperationException($"Object with ID {idStr} not found");
-
-            subtractObjects.Add(obj);
-            var brep = GetBrepFromObject(obj);
-            if (brep == null)
-                throw new InvalidOperationException($"Object {idStr} is not a solid, surface, or extrusion and cannot be used in a boolean operation");
-            subtractBreps.Add(brep);
-        }
-
-        if (subtractBreps.Count == 0)
-            throw new InvalidOperationException("Could not extract valid Breps from subtract objects");
-
-        var results = Brep.CreateBooleanDifference(baseBreps, subtractBreps, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
-
-        if (results == null || results.Length == 0)
-            throw new InvalidOperationException("Boolean difference failed - objects may not intersect or be valid solids");
 
         // Delete source objects if requested
         if (deleteSources)
@@ -164,53 +108,17 @@ public partial class RhinoMCPFunctions
     /// <summary>
     /// Perform a boolean intersection operation.
     /// </summary>
-    [McpCommand("boolean_intersection")]
+    [McpCommand("boolean_intersection", SupportsDryRun = true)]
     public JObject BooleanIntersection(JObject parameters)
     {
+        var results = ComputeBooleanIntersection(parameters, out var sourceObjects);
+
+        if (parameters["dry_run"]?.ToObject<bool>() == true)
+            return PredictBoolean(results, $"Boolean intersection would create {results.Length} object(s)");
+
         var doc = RhinoDoc.ActiveDoc;
-        var objectIds = parameters["object_ids"]?.ToObject<List<string>>();
         var deleteSources = parameters["delete_sources"]?.ToObject<bool>() ?? true;
         var name = parameters["name"]?.ToString();
-
-        if (objectIds == null || objectIds.Count < 2)
-            throw new ArgumentException("Boolean intersection requires at least 2 object IDs");
-
-        var breps = new List<Brep>();
-        var sourceObjects = new List<RhinoObject>();
-
-        foreach (var idStr in objectIds)
-        {
-            var obj = doc.Objects.Find(new Guid(idStr));
-            if (obj == null)
-                throw new InvalidOperationException($"Object with ID {idStr} not found");
-
-            sourceObjects.Add(obj);
-            var brep = GetBrepFromObject(obj);
-            if (brep == null)
-                throw new InvalidOperationException($"Object {idStr} is not a solid, surface, or extrusion and cannot be used in a boolean operation");
-            breps.Add(brep);
-        }
-
-        if (breps.Count < 2)
-            throw new InvalidOperationException("Could not extract valid Breps from the provided objects");
-
-        var results = Brep.CreateBooleanIntersection(breps[0], breps[1], RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
-
-        // For more than 2 objects, chain intersections
-        for (int i = 2; i < breps.Count && results != null && results.Length > 0; i++)
-        {
-            var newResults = new List<Brep>();
-            foreach (var r in results)
-            {
-                var intersected = Brep.CreateBooleanIntersection(r, breps[i], RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
-                if (intersected != null)
-                    newResults.AddRange(intersected);
-            }
-            results = newResults.ToArray();
-        }
-
-        if (results == null || results.Length == 0)
-            throw new InvalidOperationException("Boolean intersection failed - objects may not intersect or be valid solids");
 
         // Delete source objects if requested
         if (deleteSources)
@@ -239,6 +147,199 @@ public partial class RhinoMCPFunctions
             ["count"] = results.Length,
             ["message"] = $"Boolean intersection created {results.Length} object(s)"
         };
+    }
+
+    /// <summary>
+    /// Resolve the inputs and fuse them, returning the result Breps without
+    /// touching the document. Shared by the real run and the dry_run preview.
+    /// </summary>
+    private Brep[] ComputeBooleanUnion(JObject parameters, out List<RhinoObject> sources)
+    {
+        var doc = RhinoDoc.ActiveDoc;
+        var objectIds = parameters["object_ids"]?.ToObject<List<string>>();
+
+        if (objectIds == null || objectIds.Count < 2)
+            throw new ArgumentException("Boolean union requires at least 2 object IDs");
+
+        var breps = new List<Brep>();
+        sources = new List<RhinoObject>();
+
+        foreach (var idStr in objectIds)
+        {
+            var obj = doc.Objects.Find(new Guid(idStr));
+            if (obj == null)
+                throw new InvalidOperationException($"Object with ID {idStr} not found");
+
+            sources.Add(obj);
+            var brep = GetBrepFromObject(obj);
+            if (brep == null)
+                throw new InvalidOperationException($"Object {idStr} is not a solid, surface, or extrusion and cannot be used in a boolean operation");
+            breps.Add(brep);
+        }
+
+        if (breps.Count < 2)
+            throw new InvalidOperationException("Could not extract valid Breps from the provided objects");
+
+        var results = Brep.CreateBooleanUnion(breps, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+
+        if (results == null || results.Length == 0)
+            throw new InvalidOperationException("Boolean union failed - objects may not intersect or be valid solids");
+
+        return results;
+    }
+
+    /// <summary>
+    /// Resolve the base and subtract inputs and carve them, returning the result
+    /// Breps without touching the document. Shared by the real run and the dry_run
+    /// preview; the base object comes back out for the caller's delete pass.
+    /// </summary>
+    private Brep[] ComputeBooleanDifference(JObject parameters, out RhinoObject baseObj, out List<RhinoObject> sources)
+    {
+        var doc = RhinoDoc.ActiveDoc;
+        var baseId = parameters["base_id"]?.ToString();
+        var subtractIds = parameters["subtract_ids"]?.ToObject<List<string>>();
+
+        if (string.IsNullOrEmpty(baseId))
+            throw new ArgumentException("Boolean difference requires a base_id");
+
+        if (subtractIds == null || subtractIds.Count == 0)
+            throw new ArgumentException("Boolean difference requires at least one subtract_id");
+
+        baseObj = doc.Objects.Find(new Guid(baseId));
+        if (baseObj == null)
+            throw new InvalidOperationException($"Base object with ID {baseId} not found");
+
+        var baseBreps = new List<Brep>();
+        var baseBrep = GetBrepFromObject(baseObj);
+        if (baseBrep != null)
+            baseBreps.Add(baseBrep);
+        else
+            throw new InvalidOperationException("Could not extract valid Brep from base object");
+
+        var subtractBreps = new List<Brep>();
+        sources = new List<RhinoObject>();
+
+        foreach (var idStr in subtractIds)
+        {
+            var obj = doc.Objects.Find(new Guid(idStr));
+            if (obj == null)
+                throw new InvalidOperationException($"Object with ID {idStr} not found");
+
+            sources.Add(obj);
+            var brep = GetBrepFromObject(obj);
+            if (brep == null)
+                throw new InvalidOperationException($"Object {idStr} is not a solid, surface, or extrusion and cannot be used in a boolean operation");
+            subtractBreps.Add(brep);
+        }
+
+        if (subtractBreps.Count == 0)
+            throw new InvalidOperationException("Could not extract valid Breps from subtract objects");
+
+        var results = Brep.CreateBooleanDifference(baseBreps, subtractBreps, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+
+        if (results == null || results.Length == 0)
+            throw new InvalidOperationException("Boolean difference failed - objects may not intersect or be valid solids");
+
+        return results;
+    }
+
+    /// <summary>
+    /// Resolve the inputs and intersect them, returning the result Breps without
+    /// touching the document. Shared by the real run and the dry_run preview.
+    /// </summary>
+    private Brep[] ComputeBooleanIntersection(JObject parameters, out List<RhinoObject> sources)
+    {
+        var doc = RhinoDoc.ActiveDoc;
+        var objectIds = parameters["object_ids"]?.ToObject<List<string>>();
+
+        if (objectIds == null || objectIds.Count < 2)
+            throw new ArgumentException("Boolean intersection requires at least 2 object IDs");
+
+        var breps = new List<Brep>();
+        sources = new List<RhinoObject>();
+
+        foreach (var idStr in objectIds)
+        {
+            var obj = doc.Objects.Find(new Guid(idStr));
+            if (obj == null)
+                throw new InvalidOperationException($"Object with ID {idStr} not found");
+
+            sources.Add(obj);
+            var brep = GetBrepFromObject(obj);
+            if (brep == null)
+                throw new InvalidOperationException($"Object {idStr} is not a solid, surface, or extrusion and cannot be used in a boolean operation");
+            breps.Add(brep);
+        }
+
+        if (breps.Count < 2)
+            throw new InvalidOperationException("Could not extract valid Breps from the provided objects");
+
+        var results = Brep.CreateBooleanIntersection(breps[0], breps[1], RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+
+        // For more than 2 objects, chain intersections
+        for (int i = 2; i < breps.Count && results != null && results.Length > 0; i++)
+        {
+            var newResults = new List<Brep>();
+            foreach (var r in results)
+            {
+                var intersected = Brep.CreateBooleanIntersection(r, breps[i], RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+                if (intersected != null)
+                    newResults.AddRange(intersected);
+            }
+            results = newResults.ToArray();
+        }
+
+        if (results == null || results.Length == 0)
+            throw new InvalidOperationException("Boolean intersection failed - objects may not intersect or be valid solids");
+
+        return results;
+    }
+
+    /// <summary>
+    /// Build the dry_run response: the metrics a real run would produce, derived
+    /// from the in-memory result Breps, with no change to the document.
+    /// </summary>
+    private JObject PredictBoolean(Brep[] results, string message)
+    {
+        var predicted = new JArray();
+        foreach (var brep in results)
+            predicted.Add(DescribeResultBrep(brep));
+
+        return new JObject
+        {
+            ["dry_run"] = true,
+            ["would_succeed"] = true,
+            ["count"] = results.Length,
+            ["results"] = predicted,
+            ["message"] = message
+        };
+    }
+
+    private JObject DescribeResultBrep(Brep brep)
+    {
+        var valid = brep.IsValidWithLog(out var log);
+
+        var info = new JObject { ["valid"] = valid };
+        if (!valid)
+            info["reason"] = log;
+
+        info["is_solid"] = brep.IsSolid;
+
+        // Volume is meaningful only for a closed solid; an open Brep still yields
+        // a non-null (garbage) value, so gate on IsSolid rather than a null check.
+        if (brep.IsSolid)
+        {
+            var volume = VolumeMassProperties.Compute(brep);
+            if (volume != null)
+                info["volume"] = volume.Volume;
+        }
+
+        var area = AreaMassProperties.Compute(brep);
+        if (area != null)
+            info["area"] = area.Area;
+
+        info["bounding_box"] = Serializer.SerializeBBox(brep.GetBoundingBox(true));
+        return info;
     }
 
     /// <summary>

--- a/plugin/Functions/DescribeCapabilities.cs
+++ b/plugin/Functions/DescribeCapabilities.cs
@@ -8,16 +8,19 @@ namespace RhinoMCPPlugin.Functions;
 public partial class RhinoMCPFunctions
 {
     /// <summary>
-    /// Self-description of what this MCP server can do: every command it handles
-    /// and whether that command is read-only, plus the perception envelope flags
-    /// it honors and the plugin version. Read-only.
+    /// Self-description of what this MCP server can do: every command it handles,
+    /// whether that command is read-only and whether it honors a dry_run preview,
+    /// plus the perception envelope flags it honors and the plugin version.
+    /// Read-only.
     ///
     /// This is distinct from get_commands, which lists Rhino's own application
     /// commands (Box, Circle, ...) for use with run_command. describe_capabilities
     /// lists the MCP command surface itself, so an agent can discover what it can
     /// send instead of guessing. The command list is the live dispatch table
     /// (GetDispatchTable), so it never drifts from what the server actually
-    /// accepts: add a [McpCommand] and it appears here automatically.
+    /// accepts: add a [McpCommand] and it appears here automatically. The flags
+    /// come off the same attribute the dispatcher gates on, so a client can ask
+    /// what this plugin supports before sending a command it might mishandle.
     ///
     /// Parameters are deliberately not included. The handlers take an untyped
     /// JObject, so there is no parameter schema to reflect at runtime; the
@@ -35,7 +38,8 @@ public partial class RhinoMCPFunctions
             commands.Add(new JObject
             {
                 ["name"] = name,
-                ["read_only"] = table[name].ReadOnly
+                ["read_only"] = table[name].ReadOnly,
+                ["supports_dry_run"] = table[name].SupportsDryRun
             });
         }
 

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -1093,9 +1093,11 @@ public partial class RhinoMCPFunctions
         }
 
         // Test: describe_capabilities reports the live dispatch table with
-        // read-only flags, the perception envelope flags, and the version. The
-        // command list is reflection-driven, so it must include the commands we
-        // exercise here and describe_capabilities itself, with correct read_only.
+        // read-only and dry_run flags, the perception envelope flags, and the
+        // version. The command list is reflection-driven, so it must include the
+        // commands we exercise here and describe_capabilities itself, with the
+        // flags the dispatcher gates on. A client reads supports_dry_run before
+        // sending a preview, so a wrong flag here would cost source objects.
         try
         {
             var caps = DescribeCapabilities(new JObject());
@@ -1106,8 +1108,12 @@ public partial class RhinoMCPFunctions
                 throw new Exception("version is empty");
 
             var readOnly = new System.Collections.Generic.Dictionary<string, bool>();
+            var dryRun = new System.Collections.Generic.Dictionary<string, bool>();
             foreach (var c in cmds)
+            {
                 readOnly[c["name"].ToString()] = (bool)c["read_only"];
+                dryRun[c["name"].ToString()] = (bool)c["supports_dry_run"];
+            }
 
             if (!readOnly.ContainsKey("describe_capabilities") || !readOnly["describe_capabilities"])
                 throw new Exception("describe_capabilities should list itself as read_only");
@@ -1115,6 +1121,14 @@ public partial class RhinoMCPFunctions
                 throw new Exception("create_object should be present and not read_only");
             if (!readOnly.ContainsKey("get_document_summary") || !readOnly["get_document_summary"])
                 throw new Exception("get_document_summary should be present and read_only");
+
+            foreach (var booleanCmd in new[] { "boolean_union", "boolean_difference", "boolean_intersection" })
+            {
+                if (!dryRun.ContainsKey(booleanCmd) || !dryRun[booleanCmd])
+                    throw new Exception(booleanCmd + " should advertise supports_dry_run");
+            }
+            if (!dryRun.ContainsKey("create_object") || dryRun["create_object"])
+                throw new Exception("create_object should be present and not advertise supports_dry_run");
 
             bool hasDelta = false, hasHealth = false;
             foreach (var f in (JArray)caps["perception"]["envelope_flags"])

--- a/plugin/Functions/TestAllFunctions.cs
+++ b/plugin/Functions/TestAllFunctions.cs
@@ -1493,6 +1493,222 @@ public partial class RhinoMCPFunctions
             results["boolean_intersection_rejects_non_brep"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
         }
 
+        // Test: a dry_run boolean previews the result Brep's metrics and leaves
+        // the document untouched, then a real run on the same inputs commits.
+        // Two 10-unit boxes overlapping by 5 along X share full Y and Z extents,
+        // so their union is a single 15x10x10 solid (volume 1500); the prediction
+        // reports that count, solidity, and volume while adding and deleting
+        // nothing.
+        try
+        {
+            var pos = visualMode ? GetNextPosition() : new JArray { 230, 0, 0 };
+            var db1 = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPDryRunBox1",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = pos
+            });
+            var pos2 = new JArray { ((JArray)pos)[0].ToObject<double>() + 5, ((JArray)pos)[1].ToObject<double>(), 0 };
+            var db2 = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPDryRunBox2",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = pos2
+            });
+            string db1Id = db1["id"]?.ToString();
+            string db2Id = db2["id"]?.ToString();
+
+            var before = SnapshotObjectIds(doc);
+            var prediction = BooleanUnion(new JObject
+            {
+                ["object_ids"] = new JArray { db1Id, db2Id },
+                ["dry_run"] = true
+            });
+            var after = SnapshotObjectIds(doc);
+
+            bool predDryRun = prediction["dry_run"]?.ToObject<bool>() ?? false;
+            bool predWouldSucceed = prediction["would_succeed"]?.ToObject<bool>() ?? false;
+            bool predHasResultIds = prediction["result_ids"] != null;
+            int predCount = prediction["count"]?.ToObject<int>() ?? 0;
+            var predResults = prediction["results"] as JArray;
+            JObject predFirst = (predResults != null && predResults.Count > 0) ? (JObject)predResults[0] : null;
+            bool predValid = predFirst?["valid"]?.ToObject<bool>() ?? false;
+            bool predIsSolid = predFirst?["is_solid"]?.ToObject<bool>() ?? false;
+            bool predHasArea = predFirst?["area"] != null;
+            bool predHasBBox = predFirst?["bounding_box"] != null;
+            double predVolume = predFirst?["volume"]?.ToObject<double>() ?? 0;
+
+            bool inputsRemain = doc.Objects.Find(new Guid(db1Id)) != null
+                && doc.Objects.Find(new Guid(db2Id)) != null;
+            bool docUnchanged = before.SetEquals(after);
+
+            var real = BooleanUnion(new JObject
+            {
+                ["object_ids"] = new JArray { db1Id, db2Id },
+                ["name"] = "MCPDryRunUnionResult",
+                ["delete_sources"] = true
+            });
+            int realCount = real["count"]?.ToObject<int>() ?? 0;
+
+            DeleteObject(new JObject { ["name"] = "MCPDryRunUnionResult" });
+            if (doc.Objects.Find(new Guid(db1Id)) != null) DeleteObject(new JObject { ["id"] = db1Id });
+            if (doc.Objects.Find(new Guid(db2Id)) != null) DeleteObject(new JObject { ["id"] = db2Id });
+
+            if (!predDryRun)
+                throw new Exception("dry_run union response missing dry_run=true");
+            if (!predWouldSucceed)
+                throw new Exception("dry_run union did not report would_succeed");
+            if (predHasResultIds)
+                throw new Exception("dry_run union returned result_ids instead of a prediction");
+            if (predCount != 1)
+                throw new Exception($"dry_run union predicted count {predCount}, expected 1");
+            if (predFirst == null)
+                throw new Exception("dry_run union prediction had no result entry");
+            if (!predValid)
+                throw new Exception("dry_run union predicted an invalid result");
+            if (!predIsSolid)
+                throw new Exception("dry_run union predicted a non-solid result");
+            if (!predHasArea)
+                throw new Exception("dry_run union prediction missing area");
+            if (!predHasBBox)
+                throw new Exception("dry_run union prediction missing bounding_box");
+            if (Math.Abs(predVolume - 1500.0) > 1.0)
+                throw new Exception($"dry_run union predicted volume {predVolume}, expected ~1500");
+            if (!inputsRemain)
+                throw new Exception("dry_run union deleted an input");
+            if (!docUnchanged)
+                throw new Exception("dry_run union changed the document object set");
+            if (realCount != 1)
+                throw new Exception($"real union after dry_run created {realCount} object(s), expected 1");
+            results["boolean_dry_run_predicts_and_leaves_doc"] = new JObject { ["status"] = "pass", ["predicted_volume"] = predVolume };
+            VisualUpdate("dry_run union predicts metrics and leaves the document");
+        }
+        catch (Exception e)
+        {
+            results["boolean_dry_run_predicts_and_leaves_doc"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
+        // Test: dry_run also previews difference and intersection without mutating
+        // the document, returning the same prediction envelope and no result_ids.
+        try
+        {
+            var pos = visualMode ? GetNextPosition() : new JArray { 250, 0, 0 };
+            var dBase = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPDryRunDiffBase",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = pos
+            });
+            var dSub = CreateObject(new JObject
+            {
+                ["type"] = "SPHERE",
+                ["name"] = "MCPDryRunDiffSub",
+                ["params"] = new JObject { ["radius"] = 6 },
+                ["translation"] = pos
+            });
+            string dBaseId = dBase["id"]?.ToString();
+            string dSubId = dSub["id"]?.ToString();
+
+            var beforeDiff = SnapshotObjectIds(doc);
+            var diffPrediction = BooleanDifference(new JObject
+            {
+                ["base_id"] = dBaseId,
+                ["subtract_ids"] = new JArray { dSubId },
+                ["dry_run"] = true
+            });
+            var afterDiff = SnapshotObjectIds(doc);
+
+            bool diffDryRun = diffPrediction["dry_run"]?.ToObject<bool>() ?? false;
+            bool diffHasResultIds = diffPrediction["result_ids"] != null;
+            int diffCount = diffPrediction["count"]?.ToObject<int>() ?? 0;
+            var diffResults = diffPrediction["results"] as JArray;
+            bool diffHasBBox = diffResults != null && diffResults.Count > 0 && diffResults[0]["bounding_box"] != null;
+            bool diffDocUnchanged = beforeDiff.SetEquals(afterDiff);
+            bool diffInputsRemain = doc.Objects.Find(new Guid(dBaseId)) != null
+                && doc.Objects.Find(new Guid(dSubId)) != null;
+
+            var ipos = visualMode ? GetNextPosition() : new JArray { 270, 0, 0 };
+            var ib1 = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPDryRunIntBox1",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = ipos
+            });
+            var ipos2 = new JArray { ((JArray)ipos)[0].ToObject<double>() + 5, ((JArray)ipos)[1].ToObject<double>(), 0 };
+            var ib2 = CreateObject(new JObject
+            {
+                ["type"] = "BOX",
+                ["name"] = "MCPDryRunIntBox2",
+                ["params"] = new JObject { ["width"] = 10, ["length"] = 10, ["height"] = 10 },
+                ["translation"] = ipos2
+            });
+            string ib1Id = ib1["id"]?.ToString();
+            string ib2Id = ib2["id"]?.ToString();
+
+            var beforeInt = SnapshotObjectIds(doc);
+            var intPrediction = BooleanIntersection(new JObject
+            {
+                ["object_ids"] = new JArray { ib1Id, ib2Id },
+                ["dry_run"] = true
+            });
+            var afterInt = SnapshotObjectIds(doc);
+
+            bool intDryRun = intPrediction["dry_run"]?.ToObject<bool>() ?? false;
+            bool intHasResultIds = intPrediction["result_ids"] != null;
+            int intCount = intPrediction["count"]?.ToObject<int>() ?? 0;
+            var intResults = intPrediction["results"] as JArray;
+            JObject intFirst = (intResults != null && intResults.Count > 0) ? (JObject)intResults[0] : null;
+            bool intIsSolid = intFirst?["is_solid"]?.ToObject<bool>() ?? false;
+            double intVolume = intFirst?["volume"]?.ToObject<double>() ?? 0;
+            bool intDocUnchanged = beforeInt.SetEquals(afterInt);
+            bool intInputsRemain = doc.Objects.Find(new Guid(ib1Id)) != null
+                && doc.Objects.Find(new Guid(ib2Id)) != null;
+
+            DeleteObject(new JObject { ["id"] = dBaseId });
+            DeleteObject(new JObject { ["id"] = dSubId });
+            DeleteObject(new JObject { ["id"] = ib1Id });
+            DeleteObject(new JObject { ["id"] = ib2Id });
+
+            if (!diffDryRun)
+                throw new Exception("dry_run difference missing dry_run=true");
+            if (diffHasResultIds)
+                throw new Exception("dry_run difference returned result_ids instead of a prediction");
+            if (diffCount < 1)
+                throw new Exception("dry_run difference predicted no result");
+            if (!diffHasBBox)
+                throw new Exception("dry_run difference prediction missing bounding_box");
+            if (!diffDocUnchanged)
+                throw new Exception("dry_run difference changed the document object set");
+            if (!diffInputsRemain)
+                throw new Exception("dry_run difference deleted an input");
+            if (!intDryRun)
+                throw new Exception("dry_run intersection missing dry_run=true");
+            if (intHasResultIds)
+                throw new Exception("dry_run intersection returned result_ids instead of a prediction");
+            if (intCount < 1)
+                throw new Exception("dry_run intersection predicted no result");
+            if (intFirst == null)
+                throw new Exception("dry_run intersection prediction had no result entry");
+            if (!intIsSolid)
+                throw new Exception("dry_run intersection predicted a non-solid result");
+            if (intVolume <= 0)
+                throw new Exception($"dry_run intersection predicted volume {intVolume}, expected a positive solid volume");
+            if (!intDocUnchanged)
+                throw new Exception("dry_run intersection changed the document object set");
+            if (!intInputsRemain)
+                throw new Exception("dry_run intersection deleted an input");
+            results["boolean_dry_run_difference_and_intersection"] = new JObject { ["status"] = "pass" };
+            VisualUpdate("dry_run difference and intersection preview without mutating");
+        }
+        catch (Exception e)
+        {
+            results["boolean_dry_run_difference_and_intersection"] = new JObject { ["status"] = "fail", ["error"] = e.Message };
+        }
+
         // Cleanup
         if (!visualMode)
         {
@@ -1537,6 +1753,13 @@ public partial class RhinoMCPFunctions
                 DeleteObject(new JObject { ["name"] = "MCPBoolRejectIntBox1" });
                 DeleteObject(new JObject { ["name"] = "MCPBoolRejectIntBox2" });
                 DeleteObject(new JObject { ["name"] = "MCPBoolRejectIntLine" });
+                DeleteObject(new JObject { ["name"] = "MCPDryRunBox1" });
+                DeleteObject(new JObject { ["name"] = "MCPDryRunBox2" });
+                DeleteObject(new JObject { ["name"] = "MCPDryRunUnionResult" });
+                DeleteObject(new JObject { ["name"] = "MCPDryRunDiffBase" });
+                DeleteObject(new JObject { ["name"] = "MCPDryRunDiffSub" });
+                DeleteObject(new JObject { ["name"] = "MCPDryRunIntBox1" });
+                DeleteObject(new JObject { ["name"] = "MCPDryRunIntBox2" });
             }
             catch
             {

--- a/plugin/Functions/_Registry.cs
+++ b/plugin/Functions/_Registry.cs
@@ -15,11 +15,13 @@ public partial class RhinoMCPFunctions
     {
         public readonly Func<JObject, JObject> Handler;
         public readonly bool ReadOnly;
+        public readonly bool SupportsDryRun;
 
-        public DispatchEntry(Func<JObject, JObject> handler, bool readOnly)
+        public DispatchEntry(Func<JObject, JObject> handler, bool readOnly, bool supportsDryRun)
         {
             Handler = handler;
             ReadOnly = readOnly;
+            SupportsDryRun = supportsDryRun;
         }
     }
 
@@ -50,7 +52,7 @@ public partial class RhinoMCPFunctions
                 throw new InvalidOperationException(
                     $"Duplicate [McpCommand(\"{attr.Name}\")] on {method.Name}.");
             }
-            table[attr.Name] = new DispatchEntry(handler, attr.ReadOnly);
+            table[attr.Name] = new DispatchEntry(handler, attr.ReadOnly, attr.SupportsDryRun);
         }
 
         _dispatchTable = table;

--- a/plugin/McpCommandAttribute.cs
+++ b/plugin/McpCommandAttribute.cs
@@ -21,6 +21,15 @@ public sealed class McpCommandAttribute : Attribute
     /// </summary>
     public bool ReadOnly { get; set; }
 
+    /// <summary>
+    /// If true, the handler honors a params-level dry_run flag by previewing its
+    /// result without mutating the document. The dispatcher rejects dry_run on any
+    /// command that does not set this, and for one that does it skips the undo
+    /// record and the perception blocks since a preview changes nothing.
+    /// Settable for named-argument syntax: [McpCommand("foo", SupportsDryRun = true)].
+    /// </summary>
+    public bool SupportsDryRun { get; set; }
+
     public McpCommandAttribute(string name)
     {
         Name = name;

--- a/plugin/RhinoMCPServer.cs
+++ b/plugin/RhinoMCPServer.cs
@@ -456,8 +456,25 @@ namespace RhinoMCPPlugin
                 };
             }
 
+            // dry_run is a preview: only commands that declare SupportsDryRun know
+            // how to honor it. Reject it on any other command up front, before an
+            // undo record or snapshot, so a stray flag can never suppress undo
+            // while the handler still mutates the document.
+            bool dryRunRequested = parameters["dry_run"]?.ToObject<bool>() ?? false;
+            if (dryRunRequested && !entry.SupportsDryRun)
+            {
+                return new JObject
+                {
+                    ["status"] = "error",
+                    ["message"] = $"Command {cmdType} does not support dry_run"
+                };
+            }
+
             var doc = RhinoDoc.ActiveDoc;
-            bool needsUndo = !entry.ReadOnly;
+            // A supported dry_run previews its result and touches nothing, so it
+            // opens no undo record; needsUndo also gates the perception blocks, so
+            // a preview reports no _delta or _health, which is correct.
+            bool needsUndo = !entry.ReadOnly && !(dryRunRequested && entry.SupportsDryRun);
 
             // A change-delta or health report only makes sense for a mutating
             // command, and only when the client asked for it. Snapshot the

--- a/server/src/rhinomcp/server.py
+++ b/server/src/rhinomcp/server.py
@@ -119,6 +119,9 @@ READONLY_RETRY_COMMANDS = {
 }
 
 
+CAPABILITIES_COMMAND = "describe_capabilities"
+
+
 class TransientRhinoConnectionError(ConnectionError):
     """A connected Rhino socket dropped while a command was in flight."""
 
@@ -147,6 +150,11 @@ class RhinoConnection:
         # interleave their write/read pairs and the wrong response gets attached
         # to the wrong request.
         self._send_lock = threading.Lock()
+        # Commands the plugin on the other end of this socket says it can preview.
+        # None means "not asked yet"; connecting and dropping both reset it, so an
+        # answer from one plugin is never reused for another.
+        self._dry_run_commands: set[str] | None = None
+        self._capabilities_lock = threading.Lock()
 
     def connect(self) -> bool:
         """Connect to the Rhino addon socket server"""
@@ -156,6 +164,7 @@ class RhinoConnection:
         try:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.sock.connect((self.host, self.port))
+            self._dry_run_commands = None
             logger.info(f"Connected to Rhino at {self.host}:{self.port}")
             return True
         except Exception as e:
@@ -172,6 +181,7 @@ class RhinoConnection:
                 logger.error(f"Error disconnecting from Rhino: {str(e)}")
             finally:
                 self.sock = None
+                self._dry_run_commands = None
 
     def _recv_exact(self, sock, num_bytes, buffer_size=8192):
         """Receive exactly num_bytes from sock.
@@ -228,8 +238,60 @@ class RhinoConnection:
     ) -> Dict[str, Any]:
         """Send a command to Rhino and return the response. Thread-safe: serialized
         across concurrent callers so request/response framing isn't interleaved."""
+        if (params or {}).get("dry_run"):
+            self._require_dry_run_support(command_type)
         with self._send_lock:
             return self._send_command_locked(command_type, params)
+
+    def _require_dry_run_support(self, command_type: str):
+        """Refuse a preview the connected plugin cannot give.
+
+        Server and plugin ship separately, so a new server can meet an old
+        plugin. That plugin drops the dry_run param it has never heard of, runs
+        the real boolean, and deletes the source objects, while the caller reads
+        the reply as a preview. So the check happens here, before the send, and
+        only an explicit yes lets the command through.
+        """
+        if command_type in self._dry_run_capable_commands():
+            return
+
+        raise Exception(
+            "The installed rhinomcp plugin does not report dry_run support for "
+            f"'{command_type}', so a preview would run as the real operation and "
+            "could delete the source objects. The command was not sent. Update "
+            "the plugin to match this server version, or retry without dry_run."
+        )
+
+    def _dry_run_capable_commands(self) -> set[str]:
+        """Commands this plugin advertises a dry_run preview for.
+
+        Read once per connection and cached, so a caller that never previews
+        pays nothing and one that does pays a single extra round trip. The fetch
+        sends no dry_run of its own, so it cannot re-enter the gate. Only an
+        answer that arrived is remembered, and it is taken at its word: a command
+        the list doesn't mention, or an entry without the field, is a real no. A
+        fetch that fails refuses the call in hand without being remembered, so a
+        dropped frame costs one preview rather than every preview left on this
+        connection.
+        """
+        with self._capabilities_lock:
+            if self._dry_run_commands is None:
+                try:
+                    capabilities = self.send_command(CAPABILITIES_COMMAND, {})
+                    advertised = {
+                        entry.get("name")
+                        for entry in capabilities.get("commands", [])
+                        if isinstance(entry, dict)
+                        and entry.get("supports_dry_run") is True
+                    }
+                except Exception as e:
+                    logger.warning(
+                        f"Could not read the plugin's capabilities ({str(e)}); "
+                        "refusing this dry_run, the next one will ask again."
+                    )
+                    return set()
+                self._dry_run_commands = advertised
+            return self._dry_run_commands
 
     def _send_command_locked(
         self, command_type: str, params: Dict[str, Any] = {}

--- a/server/src/rhinomcp/tools/boolean_operations.py
+++ b/server/src/rhinomcp/tools/boolean_operations.py
@@ -41,7 +41,7 @@ def boolean_union(
         return f"{result['message']}. Result IDs: {result['result_ids']}"
     except Exception as e:
         logger.error(f"Error in boolean union: {str(e)}")
-        return f"Error in boolean union: {str(e)}"
+        raise
 
 
 @mcp.tool()
@@ -85,7 +85,7 @@ def boolean_difference(
         return f"{result['message']}. Result IDs: {result['result_ids']}"
     except Exception as e:
         logger.error(f"Error in boolean difference: {str(e)}")
-        return f"Error in boolean difference: {str(e)}"
+        raise
 
 
 @mcp.tool()
@@ -126,4 +126,4 @@ def boolean_intersection(
         return f"{result['message']}. Result IDs: {result['result_ids']}"
     except Exception as e:
         logger.error(f"Error in boolean intersection: {str(e)}")
-        return f"Error in boolean intersection: {str(e)}"
+        raise

--- a/server/src/rhinomcp/tools/boolean_operations.py
+++ b/server/src/rhinomcp/tools/boolean_operations.py
@@ -9,6 +9,7 @@ def boolean_union(
     object_ids: List[str],
     delete_sources: bool = True,
     name: Optional[str] = None,
+    dry_run: bool = False,
 ) -> str:
     """
     Perform a boolean union on multiple solid objects, combining them into one.
@@ -17,6 +18,7 @@ def boolean_union(
     - object_ids: List of object IDs (GUIDs) to union together (minimum 2)
     - delete_sources: Whether to delete the source objects after union (default: True)
     - name: Optional name for the resulting object
+    - dry_run: Preview the result and its metrics without modifying the document (default: False)
 
     Returns:
     A message indicating the result of the operation.
@@ -28,11 +30,14 @@ def boolean_union(
         params = {
             "object_ids": object_ids,
             "delete_sources": delete_sources,
+            "dry_run": dry_run,
         }
         if name:
             params["name"] = name
 
         result = rhino.send_command("boolean_union", params)
+        if dry_run:
+            return f"{result['message']}. Predicted results: {result['results']}"
         return f"{result['message']}. Result IDs: {result['result_ids']}"
     except Exception as e:
         logger.error(f"Error in boolean union: {str(e)}")
@@ -46,6 +51,7 @@ def boolean_difference(
     subtract_ids: List[str],
     delete_sources: bool = True,
     name: Optional[str] = None,
+    dry_run: bool = False,
 ) -> str:
     """
     Perform a boolean difference (subtraction) - subtract objects from a base object.
@@ -55,6 +61,7 @@ def boolean_difference(
     - subtract_ids: List of object IDs (GUIDs) to subtract from the base
     - delete_sources: Whether to delete the source objects after operation (default: True)
     - name: Optional name for the resulting object
+    - dry_run: Preview the result and its metrics without modifying the document (default: False)
 
     Returns:
     A message indicating the result of the operation.
@@ -67,11 +74,14 @@ def boolean_difference(
             "base_id": base_id,
             "subtract_ids": subtract_ids,
             "delete_sources": delete_sources,
+            "dry_run": dry_run,
         }
         if name:
             params["name"] = name
 
         result = rhino.send_command("boolean_difference", params)
+        if dry_run:
+            return f"{result['message']}. Predicted results: {result['results']}"
         return f"{result['message']}. Result IDs: {result['result_ids']}"
     except Exception as e:
         logger.error(f"Error in boolean difference: {str(e)}")
@@ -84,6 +94,7 @@ def boolean_intersection(
     object_ids: List[str],
     delete_sources: bool = True,
     name: Optional[str] = None,
+    dry_run: bool = False,
 ) -> str:
     """
     Perform a boolean intersection - keep only the overlapping volume of objects.
@@ -92,6 +103,7 @@ def boolean_intersection(
     - object_ids: List of object IDs (GUIDs) to intersect (minimum 2)
     - delete_sources: Whether to delete the source objects after operation (default: True)
     - name: Optional name for the resulting object
+    - dry_run: Preview the result and its metrics without modifying the document (default: False)
 
     Returns:
     A message indicating the result of the operation.
@@ -103,11 +115,14 @@ def boolean_intersection(
         params = {
             "object_ids": object_ids,
             "delete_sources": delete_sources,
+            "dry_run": dry_run,
         }
         if name:
             params["name"] = name
 
         result = rhino.send_command("boolean_intersection", params)
+        if dry_run:
+            return f"{result['message']}. Predicted results: {result['results']}"
         return f"{result['message']}. Result IDs: {result['result_ids']}"
     except Exception as e:
         logger.error(f"Error in boolean intersection: {str(e)}")

--- a/server/src/rhinomcp/tools/describe_capabilities.py
+++ b/server/src/rhinomcp/tools/describe_capabilities.py
@@ -17,7 +17,8 @@ def describe_capabilities(ctx: Context) -> Dict[str, Any]:
     Returns:
     - version: the plugin version
     - command_count: how many commands the server handles
-    - commands: a list of {name, read_only}, sorted by name
+    - commands: a list of {name, read_only, supports_dry_run}, sorted by name.
+      supports_dry_run is absent on plugins older than the flag; read that as no.
     - perception: the opt-in envelope flags (include_delta, include_health) and
       what each attaches to a mutating command's result
     """

--- a/server/src/rhinomcp/validation.py
+++ b/server/src/rhinomcp/validation.py
@@ -187,6 +187,9 @@ def validate_response(command_type: str, response: Dict[str, Any], raise_on_erro
         "execute_rhinoscript_python_code": "execute_script_result.json",
         "capture_viewport": "capture_viewport_result.json",
         "describe_capabilities": "capabilities.json",
+        "boolean_union": "boolean_result.json",
+        "boolean_difference": "boolean_result.json",
+        "boolean_intersection": "boolean_result.json",
     }
 
     schema_name = response_schema_map.get(command_type)

--- a/server/tests/mock_rhino_server.py
+++ b/server/tests/mock_rhino_server.py
@@ -177,6 +177,13 @@ class MockRhinoServer:
         "undo", "redo", "create_layer", "delete_layer",
     }
 
+    # Commands whose handler honors a params-level dry_run preview, mirroring the
+    # plugin's [McpCommand(..., SupportsDryRun = true)]. dry_run on anything else
+    # is rejected; a dry_run on one of these previews and carries no delta/health.
+    SUPPORTS_DRY_RUN = {
+        "boolean_union", "boolean_difference", "boolean_intersection",
+    }
+
     def _process_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
         """Process a command and return a response."""
         cmd_type = command.get("type", "")
@@ -222,15 +229,24 @@ class MockRhinoServer:
         if not handler:
             return {"status": "error", "message": f"Unknown command: {cmd_type}"}
 
+        # dry_run is a preview only the declaring commands honor; reject it on any
+        # other command up front, exactly as the plugin dispatcher does.
+        dry_run_requested = bool(params.get("dry_run"))
+        if dry_run_requested and cmd_type not in self.SUPPORTS_DRY_RUN:
+            return {"status": "error", "message": f"Command {cmd_type} does not support dry_run"}
+
         try:
             # Mirror the plugin: when the client asks for a delta, snapshot the
-            # object id set around a mutating handler and attach what changed.
+            # object id set around a mutating handler and attach what changed. A
+            # supported dry_run previews the result and changes nothing, so it
+            # carries no delta or health.
+            is_preview = dry_run_requested and cmd_type in self.SUPPORTS_DRY_RUN
             track_delta = bool(command.get("include_delta")) and (
                 cmd_type in self._MUTATING_COMMANDS
-            )
+            ) and not is_preview
             track_health = bool(command.get("include_health")) and (
                 cmd_type in self._MUTATING_COMMANDS
-            )
+            ) and not is_preview
             before = set(self.objects.keys()) if (track_delta or track_health) else None
             result = handler(params)
             if isinstance(result, dict) and (track_delta or track_health):
@@ -875,6 +891,14 @@ class MockRhinoServer:
         if len(object_ids) < 2:
             raise Exception("Boolean union requires at least 2 objects")
 
+        if params.get("dry_run"):
+            return self._boolean_prediction(
+                "Boolean union would create 1 object(s)",
+                [[-2, -2, -2], [2, 2, 2]],
+                volume=64.0,
+                area=96.0,
+            )
+
         result_id = str(uuid.uuid4())
         result = {
             "id": result_id,
@@ -901,6 +925,14 @@ class MockRhinoServer:
         if not base_id or not subtract_ids:
             raise Exception("Boolean difference requires base_id and subtract_ids")
 
+        if params.get("dry_run"):
+            return self._boolean_prediction(
+                "Boolean difference would create 1 object(s)",
+                [[-1, -1, -1], [1, 1, 1]],
+                volume=8.0,
+                area=24.0,
+            )
+
         result_id = str(uuid.uuid4())
         result = {
             "id": result_id,
@@ -926,6 +958,14 @@ class MockRhinoServer:
         if len(object_ids) < 2:
             raise Exception("Boolean intersection requires at least 2 objects")
 
+        if params.get("dry_run"):
+            return self._boolean_prediction(
+                "Boolean intersection would create 1 object(s)",
+                [[-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]],
+                volume=1.0,
+                area=6.0,
+            )
+
         result_id = str(uuid.uuid4())
         result = {
             "id": result_id,
@@ -943,6 +983,27 @@ class MockRhinoServer:
 
         self.objects[result_id] = result
         return {"result_ids": [result_id], "count": 1, "message": "Boolean intersection created 1 object(s)"}
+
+    def _boolean_prediction(self, message: str, bounding_box: list, volume: float, area: float) -> Dict:
+        """Mirror the plugin's dry_run response: the metrics a real run would
+        produce, with no object added or removed. The mock holds no real
+        geometry, so the numbers are fixed to the bounding box the matching
+        handler uses; this exercises the prediction wiring and shape."""
+        return {
+            "dry_run": True,
+            "would_succeed": True,
+            "count": 1,
+            "results": [
+                {
+                    "valid": True,
+                    "is_solid": True,
+                    "volume": volume,
+                    "area": area,
+                    "bounding_box": bounding_box,
+                }
+            ],
+            "message": message,
+        }
 
 
     def _run_command(self, params: Dict) -> Dict:

--- a/server/tests/mock_rhino_server.py
+++ b/server/tests/mock_rhino_server.py
@@ -25,12 +25,20 @@ from typing import Dict, Any, Optional
 class MockRhinoServer:
     """A mock Rhino server for testing MCP commands."""
 
-    def __init__(self, host: str = "127.0.0.1", port: int = 1999):
+    def __init__(self, host: str = "127.0.0.1", port: int = 1999,
+                 legacy_plugin: bool = False):
         self.host = host
         self.port = port
         self.server_socket: Optional[socket.socket] = None
         self.running = False
         self.thread: Optional[threading.Thread] = None
+        # Stand in for a plugin built before dry_run existed: it never advertises
+        # supports_dry_run, and it drops the flag it doesn't know about instead of
+        # previewing, so the boolean handlers mutate the document for real.
+        self.legacy_plugin = legacy_plugin
+        self._handler_table: Optional[Dict[str, Any]] = None
+        # Command types received, in order, so a test can assert what was sent.
+        self.received_commands: list = []
 
         # Mock document state
         self.objects: Dict[str, Dict[str, Any]] = {}
@@ -184,12 +192,13 @@ class MockRhinoServer:
         "boolean_union", "boolean_difference", "boolean_intersection",
     }
 
-    def _process_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        """Process a command and return a response."""
-        cmd_type = command.get("type", "")
-        params = command.get("params", {})
+    def _handlers(self) -> Dict[str, Any]:
+        """The mock's command surface, built once. describe_capabilities reports
+        it, the same way the plugin reports its reflected dispatch table."""
+        if self._handler_table is not None:
+            return self._handler_table
 
-        handlers = {
+        self._handler_table = {
             "get_document_summary": self._get_document_summary,
             "get_objects": self._get_objects,
             "create_object": self._create_object,
@@ -224,10 +233,22 @@ class MockRhinoServer:
             "offset_curve": self._offset_curve,
             "pipe": self._pipe,
         }
+        return self._handler_table
 
-        handler = handlers.get(cmd_type)
+    def _process_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
+        """Process a command and return a response."""
+        cmd_type = command.get("type", "")
+        params = command.get("params", {})
+        self.received_commands.append(cmd_type)
+
+        handler = self._handlers().get(cmd_type)
         if not handler:
             return {"status": "error", "message": f"Unknown command: {cmd_type}"}
+
+        if self.legacy_plugin:
+            # An old plugin has no notion of dry_run, so it drops the unknown
+            # param and runs the command for real.
+            params = {k: v for k, v in params.items() if k != "dry_run"}
 
         # dry_run is a preview only the declaring commands honor; reject it on any
         # other command up front, exactly as the plugin dispatcher does.
@@ -1169,17 +1190,21 @@ class MockRhinoServer:
         return {"count": len(matched), "commands": matched}
 
     def _describe_capabilities(self, params: Dict) -> Dict:
-        """Representative capabilities shape. The real plugin reflects its live
-        dispatch table; the mock returns a fixed, well-formed sample so the
-        wiring and the response shape can be exercised."""
+        """Self-description built from the mock's own handler table, the way the
+        real plugin builds it from its live dispatch table. In legacy_plugin mode
+        supports_dry_run is left out of every entry, which is all an old plugin's
+        answer can say."""
+        commands = []
+        for name in sorted(self._handlers()):
+            entry = {"name": name, "read_only": name not in self._MUTATING_COMMANDS}
+            if not self.legacy_plugin:
+                entry["supports_dry_run"] = name in self.SUPPORTS_DRY_RUN
+            commands.append(entry)
+
         return {
             "version": "0.0.0-mock",
-            "command_count": 3,
-            "commands": [
-                {"name": "create_object", "read_only": False},
-                {"name": "delete_object", "read_only": False},
-                {"name": "get_document_summary", "read_only": True},
-            ],
+            "command_count": len(commands),
+            "commands": commands,
             "perception": {
                 "description": "Mutating commands accept opt-in envelope flags.",
                 "envelope_flags": [

--- a/server/tests/test_connection.py
+++ b/server/tests/test_connection.py
@@ -250,6 +250,192 @@ class TestConcurrencySafety:
         conn._send_lock.release()
 
 
+class TestDryRunCapabilityGate:
+    """A dry_run only goes out to a plugin that says it can preview that command.
+    A plugin from before the flag existed ignores it and runs the real operation,
+    deleting the sources, so every answer short of an explicit yes has to read as
+    no and the command must not leave the client."""
+
+    IDS = [
+        "12345678-1234-1234-1234-123456789012",
+        "87654321-4321-4321-4321-210987654321",
+    ]
+
+    def _capabilities(self, commands):
+        return frame(json.dumps({
+            "status": "success",
+            "result": {
+                "version": "0.0.0-test",
+                "command_count": len(commands),
+                "commands": commands,
+                "perception": {"description": "none", "envelope_flags": []},
+            },
+        }).encode("utf-8"))
+
+    def _preview(self):
+        return frame(json.dumps({
+            "status": "success",
+            "result": {
+                "dry_run": True,
+                "would_succeed": True,
+                "count": 1,
+                "results": [{"valid": True, "is_solid": True, "volume": 8.0,
+                             "area": 24.0, "bounding_box": [[0, 0, 0], [2, 2, 2]]}],
+                "message": "Boolean union would create 1 object(s)",
+            },
+        }).encode("utf-8"))
+
+    def _connected(self, mock_socket_class, wire):
+        from rhinomcp.server import RhinoConnection
+
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = buffered_recv(wire)
+        mock_socket_class.return_value = mock_sock
+
+        conn = RhinoConnection(host="127.0.0.1", port=1999)
+        conn.connect()
+        return conn, mock_sock
+
+    @patch("socket.socket")
+    def test_refused_when_the_plugin_has_no_describe_capabilities(self, mock_socket_class):
+        """The oldest case: a plugin that doesn't even answer the question."""
+        unknown = frame(json.dumps({
+            "status": "error",
+            "message": "Unknown command type: describe_capabilities",
+        }).encode("utf-8"))
+        conn, mock_sock = self._connected(mock_socket_class, unknown)
+
+        with pytest.raises(Exception, match="does not report dry_run support"):
+            conn.send_command(
+                "boolean_union", {"object_ids": self.IDS, "dry_run": True}
+            )
+
+        assert mock_sock.sendall.call_count == 1
+
+    @patch("socket.socket")
+    def test_refused_when_the_command_is_absent_from_the_list(self, mock_socket_class):
+        conn, mock_sock = self._connected(
+            mock_socket_class,
+            self._capabilities([
+                {"name": "create_object", "read_only": False, "supports_dry_run": False},
+            ]),
+        )
+
+        with pytest.raises(Exception, match="does not report dry_run support"):
+            conn.send_command(
+                "boolean_union", {"object_ids": self.IDS, "dry_run": True}
+            )
+
+        assert mock_sock.sendall.call_count == 1
+
+    @patch("socket.socket")
+    def test_refused_when_the_entry_omits_the_field(self, mock_socket_class):
+        """An older plugin lists the command but says nothing about previews."""
+        conn, mock_sock = self._connected(
+            mock_socket_class,
+            self._capabilities([{"name": "boolean_union", "read_only": False}]),
+        )
+
+        with pytest.raises(Exception, match="does not report dry_run support"):
+            conn.send_command(
+                "boolean_union", {"object_ids": self.IDS, "dry_run": True}
+            )
+
+        assert mock_sock.sendall.call_count == 1
+
+    @patch("socket.socket")
+    def test_sent_when_the_plugin_advertises_the_command(self, mock_socket_class):
+        conn, mock_sock = self._connected(
+            mock_socket_class,
+            self._capabilities([
+                {"name": "boolean_union", "read_only": False, "supports_dry_run": True},
+            ]) + self._preview(),
+        )
+
+        result = conn.send_command(
+            "boolean_union", {"object_ids": self.IDS, "dry_run": True}
+        )
+
+        assert result["dry_run"] is True
+        assert mock_sock.sendall.call_count == 2
+
+    @patch("socket.socket")
+    def test_a_command_without_dry_run_never_asks(self, mock_socket_class):
+        """Nothing changes for callers who don't preview: no lookup, no extra
+        round trip."""
+        committed = frame(json.dumps({
+            "status": "success",
+            "result": {"result_ids": [self.IDS[0]], "count": 1,
+                       "message": "Boolean union created 1 object(s)"},
+        }).encode("utf-8"))
+        conn, mock_sock = self._connected(mock_socket_class, committed)
+
+        conn.send_command("boolean_union", {"object_ids": self.IDS})
+
+        assert mock_sock.sendall.call_count == 1
+        assert conn._dry_run_commands is None
+
+    @patch("socket.socket")
+    def test_a_failed_probe_is_not_remembered(self, mock_socket_class):
+        """A blip while asking is not an answer. It refuses the preview in hand,
+        but the next one asks again instead of the connection being stuck on
+        "update the plugin" for a socket that merely hiccuped."""
+        from rhinomcp.server import RhinoConnection
+
+        serve = buffered_recv(
+            self._capabilities([
+                {"name": "boolean_union", "read_only": False, "supports_dry_run": True},
+            ]) + self._preview()
+        )
+        reads = []
+
+        def recv(n):
+            reads.append(n)
+            if len(reads) == 1:
+                raise socket.timeout("timed out")
+            return serve(n)
+
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = recv
+        mock_socket_class.return_value = mock_sock
+
+        conn = RhinoConnection(host="127.0.0.1", port=1999)
+        conn.connect()
+
+        with pytest.raises(Exception, match="does not report dry_run support"):
+            conn.send_command(
+                "boolean_union", {"object_ids": self.IDS, "dry_run": True}
+            )
+        assert conn._dry_run_commands is None
+
+        result = conn.send_command(
+            "boolean_union", {"object_ids": self.IDS, "dry_run": True}
+        )
+
+        assert result["dry_run"] is True
+        assert conn._dry_run_commands == {"boolean_union"}
+
+    @patch("socket.socket")
+    def test_a_dropped_connection_drops_the_answer(self, mock_socket_class):
+        """The next socket may reach a different plugin, so the cache dies with
+        the old one."""
+        capabilities = self._capabilities([
+            {"name": "boolean_union", "read_only": False, "supports_dry_run": True},
+        ])
+        conn, mock_sock = self._connected(
+            mock_socket_class,
+            capabilities + self._preview() + capabilities + self._preview(),
+        )
+
+        conn.send_command("boolean_union", {"object_ids": self.IDS, "dry_run": True})
+        conn.disconnect()
+        assert conn._dry_run_commands is None
+
+        conn.send_command("boolean_union", {"object_ids": self.IDS, "dry_run": True})
+
+        assert mock_sock.sendall.call_count == 4
+
+
 class TestRuntimeValidation:
     """Pre-flight schema validation modes."""
 

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -407,6 +407,128 @@ class TestBooleanOperations:
 
         assert result["count"] == 1
 
+    def test_boolean_union_dry_run_predicts_then_commits(self, mock_server):
+        """A dry_run union returns a prediction and leaves the document
+        untouched; the same inputs then commit for real."""
+        from rhinomcp.server import get_rhino_connection
+
+        conn = get_rhino_connection()
+
+        obj1 = conn.send_command("create_object", {"type": "BOX", "params": {"width": 1, "length": 1, "height": 1}})
+        obj2 = conn.send_command("create_object", {"type": "BOX", "params": {"width": 1, "length": 1, "height": 1}})
+
+        before = conn.send_command("get_document_summary", {})["object_count"]
+
+        prediction = conn.send_command("boolean_union", {
+            "object_ids": [obj1["id"], obj2["id"]],
+            "dry_run": True,
+        })
+
+        after = conn.send_command("get_document_summary", {})["object_count"]
+
+        assert prediction["dry_run"] is True
+        assert prediction["would_succeed"] is True
+        assert prediction["count"] == 1
+        assert "result_ids" not in prediction
+        entry = prediction["results"][0]
+        assert entry["valid"] is True
+        assert entry["is_solid"] is True
+        assert entry["volume"] > 0
+        assert "area" in entry
+        assert "bounding_box" in entry
+
+        # The preview added and removed nothing, so both inputs still resolve.
+        assert after == before
+        conn.send_command("get_object_info", {"id": obj1["id"]})
+        conn.send_command("get_object_info", {"id": obj2["id"]})
+
+        committed = conn.send_command("boolean_union", {
+            "object_ids": [obj1["id"], obj2["id"]],
+            "name": "CommittedUnion",
+        })
+        assert committed["count"] == 1
+        assert len(committed["result_ids"]) == 1
+
+    def test_boolean_difference_dry_run_leaves_inputs(self, mock_server):
+        """A dry_run difference previews without deleting the base or subtract
+        inputs."""
+        from rhinomcp.server import get_rhino_connection
+
+        conn = get_rhino_connection()
+
+        base = conn.send_command("create_object", {"type": "BOX", "params": {"width": 1, "length": 1, "height": 1}})
+        subtract = conn.send_command("create_object", {"type": "SPHERE", "params": {"radius": 1}})
+
+        prediction = conn.send_command("boolean_difference", {
+            "base_id": base["id"],
+            "subtract_ids": [subtract["id"]],
+            "dry_run": True,
+        })
+
+        assert prediction["dry_run"] is True
+        assert "result_ids" not in prediction
+        assert prediction["results"][0]["bounding_box"] is not None
+        conn.send_command("get_object_info", {"id": base["id"]})
+        conn.send_command("get_object_info", {"id": subtract["id"]})
+
+
+class TestDryRunContract:
+    """dry_run is a declared, per-command capability: unsupported commands
+    reject it, and both boolean shapes hold up under strict response validation."""
+
+    def test_dry_run_rejected_on_unsupported_command(self, mock_server):
+        """create_object does not declare dry_run support, so the flag is
+        rejected with a clear error and nothing is created, mirroring the plugin
+        dispatcher's fail-closed check."""
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_VALIDATE
+        srv._rhino_connection = None
+        srv.RHINO_VALIDATE = "off"  # bypass pre-flight so the request reaches the mock
+        try:
+            conn = get_rhino_connection()
+            with pytest.raises(Exception, match="does not support dry_run"):
+                conn.send_command("create_object", {
+                    "type": "BOX",
+                    "params": {"width": 1, "length": 1, "height": 1},
+                    "dry_run": True,
+                })
+        finally:
+            srv.RHINO_VALIDATE = original
+            srv._rhino_connection = None
+
+    def test_real_and_dry_run_validate_in_strict_mode(self, mock_server):
+        """Under strict response validation, a real boolean and a dry_run boolean
+        both pass responses/boolean_result.json; a shape drift would raise here."""
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_VALIDATE
+        srv._rhino_connection = None
+        srv.RHINO_VALIDATE = "strict"
+        try:
+            conn = get_rhino_connection()
+            a = conn.send_command("create_object", {"type": "BOX", "params": {"width": 1, "length": 1, "height": 1}})
+            b = conn.send_command("create_object", {"type": "BOX", "params": {"width": 1, "length": 1, "height": 1}})
+
+            preview = conn.send_command("boolean_union", {
+                "object_ids": [a["id"], b["id"]],
+                "dry_run": True,
+            })
+            assert preview["dry_run"] is True
+            assert "result_ids" not in preview
+
+            committed = conn.send_command("boolean_union", {
+                "object_ids": [a["id"], b["id"]],
+                "name": "StrictUnion",
+            })
+            assert "result_ids" in committed
+            assert committed["count"] == 1
+        finally:
+            srv.RHINO_VALIDATE = original
+            srv._rhino_connection = None
+
 
 class TestLayers:
     """Integration tests for layer operations."""
@@ -757,6 +879,35 @@ class TestChangeDeltaPerception:
             self._restore(original)
 
         assert "_delta" not in result
+
+    def test_dry_run_carries_no_delta_or_health(self, mock_server):
+        """A dry_run mutates nothing, so with perception on it still comes back
+        with no _delta or _health block."""
+        import rhinomcp.server as srv
+        from rhinomcp.server import get_rhino_connection
+
+        original = srv.RHINO_PERCEPTION
+        self._enable()
+        try:
+            conn = get_rhino_connection()
+            obj1 = conn.send_command("create_object", {
+                "type": "BOX", "name": "DryDeltaA",
+                "params": {"width": 1, "length": 1, "height": 1},
+            })
+            obj2 = conn.send_command("create_object", {
+                "type": "BOX", "name": "DryDeltaB",
+                "params": {"width": 1, "length": 1, "height": 1},
+            })
+            prediction = conn.send_command("boolean_union", {
+                "object_ids": [obj1["id"], obj2["id"]],
+                "dry_run": True,
+            })
+        finally:
+            self._restore(original)
+
+        assert prediction["dry_run"] is True
+        assert "_delta" not in prediction
+        assert "_health" not in prediction
 
     def test_large_op_truncates_id_lists(self, mock_server):
         """A single operation that creates more than the cap reports exact

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -658,6 +658,20 @@ class TestDryRunCapabilityGate:
         assert b in legacy_mock_server.objects
         assert "boolean_intersection" not in legacy_mock_server.received_commands
 
+    def test_the_wrapper_surfaces_the_refusal_as_a_tool_error(self, legacy_mock_server, monkeypatch):
+        """What the user gets: asking boolean_union for a preview against an old
+        plugin fails the tool call and leaves both objects standing."""
+        from rhinomcp.tools.boolean_operations import boolean_union
+
+        conn = self._connection(monkeypatch, 19998)
+        a, b = self._two_boxes(conn)
+        before = set(legacy_mock_server.objects)
+
+        with pytest.raises(Exception, match="does not report dry_run support"):
+            boolean_union(ctx=None, object_ids=[a, b], dry_run=True)
+
+        assert set(legacy_mock_server.objects) == before
+
     def test_old_plugin_serves_a_normal_boolean_unchanged(self, legacy_mock_server, monkeypatch):
         """Without dry_run nothing is gated: the command goes straight out and
         the capability lookup never happens, so the old plugin is served exactly

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -34,6 +34,19 @@ def mock_server():
     server.stop()
 
 
+@pytest.fixture
+def legacy_mock_server():
+    """A plugin from before dry_run existed, on its own port. Tests reach it
+    through an explicit connection, so the global one is left alone."""
+    server = MockRhinoServer(port=19998, legacy_plugin=True)
+    server.start()
+    time.sleep(0.1)
+
+    yield server
+
+    server.stop()
+
+
 class TestCreateObject:
     """Integration tests for create_object."""
 
@@ -477,18 +490,18 @@ class TestDryRunContract:
     reject it, and both boolean shapes hold up under strict response validation."""
 
     def test_dry_run_rejected_on_unsupported_command(self, mock_server):
-        """create_object does not declare dry_run support, so the flag is
-        rejected with a clear error and nothing is created, mirroring the plugin
-        dispatcher's fail-closed check."""
+        """create_object does not declare dry_run support, so the client refuses
+        to send it at all: the flag never reaches the plugin."""
         import rhinomcp.server as srv
         from rhinomcp.server import get_rhino_connection
 
         original = srv.RHINO_VALIDATE
         srv._rhino_connection = None
-        srv.RHINO_VALIDATE = "off"  # bypass pre-flight so the request reaches the mock
+        srv.RHINO_VALIDATE = "off"  # bypass pre-flight so only the gate can refuse
+        mock_server.received_commands.clear()
         try:
             conn = get_rhino_connection()
-            with pytest.raises(Exception, match="does not support dry_run"):
+            with pytest.raises(Exception, match="does not report dry_run support"):
                 conn.send_command("create_object", {
                     "type": "BOX",
                     "params": {"width": 1, "length": 1, "height": 1},
@@ -497,6 +510,23 @@ class TestDryRunContract:
         finally:
             srv.RHINO_VALIDATE = original
             srv._rhino_connection = None
+
+        assert "create_object" not in mock_server.received_commands
+
+    def test_plugin_still_rejects_dry_run_it_cannot_honor(self, mock_server):
+        """The plugin keeps its own fail-closed check for clients that don't gate,
+        mirroring the dispatcher in RhinoMCPServer.ExecuteCommandInternal."""
+        response = mock_server._process_command({
+            "type": "create_object",
+            "params": {
+                "type": "BOX",
+                "params": {"width": 1, "length": 1, "height": 1},
+                "dry_run": True,
+            },
+        })
+
+        assert response["status"] == "error"
+        assert "does not support dry_run" in response["message"]
 
     def test_real_and_dry_run_validate_in_strict_mode(self, mock_server):
         """Under strict response validation, a real boolean and a dry_run boolean
@@ -528,6 +558,173 @@ class TestDryRunContract:
         finally:
             srv.RHINO_VALIDATE = original
             srv._rhino_connection = None
+
+
+class TestDryRunCapabilityGate:
+    """The server and the plugin ship separately, so a server that knows dry_run
+    can end up talking to a plugin that doesn't. That plugin drops the flag it
+    has never heard of and runs the real boolean, deleting the sources, while the
+    caller believes it asked for a preview. So the client refuses to send a
+    preview unless the plugin advertises support for that exact command.
+
+    Each test drives its own connection at an explicit port, the way
+    TestPerceptionPassthrough does: hermetic, never able to fall back to a real
+    Rhino on the default port, and immune to the module-reload ordering that can
+    leave a wrapper's import-time binding pointed elsewhere.
+    """
+
+    def _connection(self, monkeypatch, port):
+        from rhinomcp.server import RhinoConnection
+        import rhinomcp.tools.boolean_operations as boolean_mod
+
+        conn = RhinoConnection(host="127.0.0.1", port=port)
+        monkeypatch.setattr(boolean_mod, "get_rhino_connection", lambda: conn)
+        return conn
+
+    def _two_boxes(self, conn):
+        a = conn.send_command("create_object", {
+            "type": "BOX", "name": "GateA",
+            "params": {"width": 1, "length": 1, "height": 1}})
+        b = conn.send_command("create_object", {
+            "type": "BOX", "name": "GateB",
+            "params": {"width": 1, "length": 1, "height": 1}})
+        return a["id"], b["id"]
+
+    def test_old_plugin_would_run_the_real_boolean(self, legacy_mock_server):
+        """What the gate is there to stop, pinned: drive the old plugin directly
+        and the dry_run union deletes both sources and reports real result ids."""
+        a = legacy_mock_server._create_object({"type": "BOX", "name": "IgnoredA"})
+        b = legacy_mock_server._create_object({"type": "BOX", "name": "IgnoredB"})
+
+        response = legacy_mock_server._process_command({
+            "type": "boolean_union",
+            "params": {"object_ids": [a["id"], b["id"]], "dry_run": True},
+        })
+
+        assert response["status"] == "success"
+        assert "result_ids" in response["result"]
+        assert a["id"] not in legacy_mock_server.objects
+        assert b["id"] not in legacy_mock_server.objects
+
+    def test_union_dry_run_refused_and_sources_survive(self, legacy_mock_server, monkeypatch):
+        conn = self._connection(monkeypatch, 19998)
+        a, b = self._two_boxes(conn)
+        before = set(legacy_mock_server.objects)
+
+        with pytest.raises(Exception, match="does not report dry_run support"):
+            conn.send_command("boolean_union", {
+                "object_ids": [a, b],
+                "delete_sources": True,
+                "dry_run": True,
+            })
+
+        assert set(legacy_mock_server.objects) == before
+        assert a in legacy_mock_server.objects
+        assert b in legacy_mock_server.objects
+        assert "boolean_union" not in legacy_mock_server.received_commands
+
+    def test_difference_dry_run_refused_and_sources_survive(self, legacy_mock_server, monkeypatch):
+        conn = self._connection(monkeypatch, 19998)
+        base, subtract = self._two_boxes(conn)
+        before = set(legacy_mock_server.objects)
+
+        with pytest.raises(Exception, match="does not report dry_run support"):
+            conn.send_command("boolean_difference", {
+                "base_id": base,
+                "subtract_ids": [subtract],
+                "delete_sources": True,
+                "dry_run": True,
+            })
+
+        assert set(legacy_mock_server.objects) == before
+        assert base in legacy_mock_server.objects
+        assert subtract in legacy_mock_server.objects
+        assert "boolean_difference" not in legacy_mock_server.received_commands
+
+    def test_intersection_dry_run_refused_and_sources_survive(self, legacy_mock_server, monkeypatch):
+        conn = self._connection(monkeypatch, 19998)
+        a, b = self._two_boxes(conn)
+        before = set(legacy_mock_server.objects)
+
+        with pytest.raises(Exception, match="does not report dry_run support"):
+            conn.send_command("boolean_intersection", {
+                "object_ids": [a, b],
+                "delete_sources": True,
+                "dry_run": True,
+            })
+
+        assert set(legacy_mock_server.objects) == before
+        assert a in legacy_mock_server.objects
+        assert b in legacy_mock_server.objects
+        assert "boolean_intersection" not in legacy_mock_server.received_commands
+
+    def test_old_plugin_serves_a_normal_boolean_unchanged(self, legacy_mock_server, monkeypatch):
+        """Without dry_run nothing is gated: the command goes straight out and
+        the capability lookup never happens, so the old plugin is served exactly
+        as it was before."""
+        from rhinomcp.tools.boolean_operations import boolean_union
+
+        conn = self._connection(monkeypatch, 19998)
+        a, b = self._two_boxes(conn)
+
+        result = boolean_union(ctx=None, object_ids=[a, b], name="OldPluginUnion")
+
+        assert "Boolean union created" in result
+        assert "describe_capabilities" not in legacy_mock_server.received_commands
+
+    def test_dry_run_runs_end_to_end_when_the_plugin_advertises_it(self, mock_server, monkeypatch):
+        from rhinomcp.tools.boolean_operations import boolean_union
+
+        conn = self._connection(monkeypatch, 19999)
+        a, b = self._two_boxes(conn)
+
+        result = boolean_union(ctx=None, object_ids=[a, b], dry_run=True)
+
+        assert "Boolean union would create" in result
+        assert "Predicted results" in result
+        assert a in mock_server.objects
+        assert b in mock_server.objects
+
+    def test_capabilities_read_once_per_connection(self, mock_server, monkeypatch):
+        """The answer is cached, so several previews share one lookup, and the
+        lookup itself never re-enters the gate."""
+        from rhinomcp.tools.boolean_operations import boolean_union
+
+        conn = self._connection(monkeypatch, 19999)
+        a, b = self._two_boxes(conn)
+        mock_server.received_commands.clear()
+
+        for _ in range(3):
+            boolean_union(ctx=None, object_ids=[a, b], dry_run=True)
+
+        assert mock_server.received_commands.count("describe_capabilities") == 1
+        assert mock_server.received_commands.count("boolean_union") == 3
+
+    def test_reconnect_rereads_capabilities(self, mock_server, monkeypatch):
+        """A reconnect can land on a different plugin, so the cached answer dies
+        with the socket."""
+        from rhinomcp.tools.boolean_operations import boolean_union
+
+        conn = self._connection(monkeypatch, 19999)
+        a, b = self._two_boxes(conn)
+        mock_server.received_commands.clear()
+
+        boolean_union(ctx=None, object_ids=[a, b], dry_run=True)
+        conn.disconnect()
+        boolean_union(ctx=None, object_ids=[a, b], dry_run=True)
+
+        assert mock_server.received_commands.count("describe_capabilities") == 2
+
+    def test_describe_capabilities_is_callable_normally(self, mock_server, monkeypatch):
+        """The gate reads capabilities by sending describe_capabilities, so that
+        command has to stay callable in its own right."""
+        conn = self._connection(monkeypatch, 19999)
+
+        result = conn.send_command("describe_capabilities", {})
+
+        by_name = {c["name"]: c for c in result["commands"]}
+        assert by_name["boolean_union"]["supports_dry_run"] is True
+        assert by_name["create_object"]["supports_dry_run"] is False
 
 
 class TestLayers:

--- a/server/tests/test_tools.py
+++ b/server/tests/test_tools.py
@@ -923,6 +923,98 @@ class TestBooleanOperationsTools:
         assert call_args[0][1]["object_ids"] == ["id1", "id2", "id3"]
         assert "Boolean intersection created" in result
 
+    @patch('rhinomcp.tools.boolean_operations.get_rhino_connection')
+    def test_boolean_union_default_is_not_dry_run(self, mock_get_conn):
+        from rhinomcp.tools.boolean_operations import boolean_union
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "result_ids": ["result-123"],
+            "count": 1,
+            "message": "Boolean union created 1 object(s)"
+        }
+        mock_get_conn.return_value = mock_conn
+
+        boolean_union(ctx=None, object_ids=["id1", "id2"])
+
+        call_args = mock_conn.send_command.call_args
+        assert call_args[0][1]["dry_run"] is False
+
+    @patch('rhinomcp.tools.boolean_operations.get_rhino_connection')
+    def test_boolean_union_dry_run_threads_param_and_formats_prediction(self, mock_get_conn):
+        from rhinomcp.tools.boolean_operations import boolean_union
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "dry_run": True,
+            "would_succeed": True,
+            "count": 1,
+            "results": [
+                {"valid": True, "is_solid": True, "volume": 64.0, "area": 96.0,
+                 "bounding_box": [[-2, -2, -2], [2, 2, 2]]}
+            ],
+            "message": "Boolean union would create 1 object(s)"
+        }
+        mock_get_conn.return_value = mock_conn
+
+        result = boolean_union(ctx=None, object_ids=["id1", "id2"], dry_run=True)
+
+        call_args = mock_conn.send_command.call_args
+        assert call_args[0][0] == "boolean_union"
+        assert call_args[0][1]["dry_run"] is True
+        assert "Boolean union would create" in result
+        assert "Predicted results" in result
+
+    @patch('rhinomcp.tools.boolean_operations.get_rhino_connection')
+    def test_boolean_difference_dry_run_threads_param(self, mock_get_conn):
+        from rhinomcp.tools.boolean_operations import boolean_difference
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "dry_run": True,
+            "would_succeed": True,
+            "count": 1,
+            "results": [
+                {"valid": True, "is_solid": True, "volume": 8.0, "area": 24.0,
+                 "bounding_box": [[-1, -1, -1], [1, 1, 1]]}
+            ],
+            "message": "Boolean difference would create 1 object(s)"
+        }
+        mock_get_conn.return_value = mock_conn
+
+        result = boolean_difference(
+            ctx=None, base_id="base-id", subtract_ids=["sub1"], dry_run=True
+        )
+
+        call_args = mock_conn.send_command.call_args
+        assert call_args[0][1]["dry_run"] is True
+        assert "Predicted results" in result
+
+    @patch('rhinomcp.tools.boolean_operations.get_rhino_connection')
+    def test_boolean_intersection_dry_run_threads_param(self, mock_get_conn):
+        from rhinomcp.tools.boolean_operations import boolean_intersection
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.return_value = {
+            "dry_run": True,
+            "would_succeed": True,
+            "count": 1,
+            "results": [
+                {"valid": True, "is_solid": True, "volume": 1.0, "area": 6.0,
+                 "bounding_box": [[-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]]}
+            ],
+            "message": "Boolean intersection would create 1 object(s)"
+        }
+        mock_get_conn.return_value = mock_conn
+
+        result = boolean_intersection(
+            ctx=None, object_ids=["id1", "id2"], dry_run=True
+        )
+
+        call_args = mock_conn.send_command.call_args
+        assert call_args[0][1]["dry_run"] is True
+        assert "Predicted results" in result
+
 
 class TestUndoRedoTools:
     """Tests for undo and redo tools."""

--- a/server/tests/test_tools.py
+++ b/server/tests/test_tools.py
@@ -1015,6 +1015,41 @@ class TestBooleanOperationsTools:
         assert call_args[0][1]["dry_run"] is True
         assert "Predicted results" in result
 
+    @patch('rhinomcp.tools.boolean_operations.get_rhino_connection')
+    def test_boolean_union_propagates_the_failure(self, mock_get_conn):
+        """A failed boolean is a failed tool call, not a successful string that
+        happens to start with "Error"."""
+        from rhinomcp.tools.boolean_operations import boolean_union
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.side_effect = Exception("Boolean union failed on 2 objects")
+        mock_get_conn.return_value = mock_conn
+
+        with pytest.raises(Exception, match="Boolean union failed on 2 objects"):
+            boolean_union(ctx=None, object_ids=["id1", "id2"])
+
+    @patch('rhinomcp.tools.boolean_operations.get_rhino_connection')
+    def test_boolean_difference_propagates_the_failure(self, mock_get_conn):
+        from rhinomcp.tools.boolean_operations import boolean_difference
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.side_effect = Exception("Boolean difference failed")
+        mock_get_conn.return_value = mock_conn
+
+        with pytest.raises(Exception, match="Boolean difference failed"):
+            boolean_difference(ctx=None, base_id="base-id", subtract_ids=["sub1"])
+
+    @patch('rhinomcp.tools.boolean_operations.get_rhino_connection')
+    def test_boolean_intersection_propagates_the_failure(self, mock_get_conn):
+        from rhinomcp.tools.boolean_operations import boolean_intersection
+
+        mock_conn = MagicMock()
+        mock_conn.send_command.side_effect = Exception("Boolean intersection failed")
+        mock_get_conn.return_value = mock_conn
+
+        with pytest.raises(Exception, match="Boolean intersection failed"):
+            boolean_intersection(ctx=None, object_ids=["id1", "id2"])
+
 
 class TestUndoRedoTools:
     """Tests for undo and redo tools."""


### PR DESCRIPTION
**The problem.** An agent driving the booleans works blind: whether a union will fuse, fall apart into untouched pieces, or fail outright depends on geometry the model cannot see, and the only way to find out today is to mutate the document and inspect the result. The perception envelope reports what a command did; nothing reports what a command would do. Implements the proposal in #46 with the four points from your reply.

**The change.** An opt-in `dry_run` boolean parameter (default false, same pattern as `delete_sources`) on `boolean_union`, `boolean_difference` and `boolean_intersection`. With `dry_run` true the handler runs the same compute path with the same tolerance, then instead of committing returns a prediction: `{dry_run, would_succeed, count, results[]}` where each result carries `valid` (IsValidWithLog, with the reason when invalid), `is_solid`, `volume`, `area` and `bounding_box`. The document is untouched and a dry run that would fail raises the same error the real call would.

**How it is built.** Each handler's resolve-extract-compute block is extracted into a private `ComputeBooleanX` method that both the real path and the preview call, so the prediction and the commit share one code path and cannot drift; the commit tail is unchanged. Support is declared on the attribute, `[McpCommand("boolean_union", SupportsDryRun = true)]`, and the dispatcher rejects `dry_run` on any command that does not declare it ("Command X does not support dry_run") before anything executes, so a stray flag can never silently run the real mutation. For a supported dry run the dispatcher skips the undo record and the `_delta`/`_health` attachment off the same declared flag, since a prediction has no document effect to report. Two behaviors the preview refuses to fake: VolumeMassProperties returns a finite but meaningless number for open breps (a unit cube missing one face reports volume 0.833), so volume is only reported when the result is actually solid, and CreateBooleanUnion on disjoint solids returns the inputs unchanged rather than failing, so the message says plainly when nothing would merge.

**Contract.** A shared `contracts/responses/boolean_result.json` covers both shapes (oneOf on the `dry_run` key): the committed shape `{result_ids, count, message}` and the preview shape, wired into the response validation map for all three commands. Per preview result, `valid`, `is_solid` and `bounding_box` are required while `volume` and `area` stay optional, because an invalid result can legitimately lack both (the preview exists to surface exactly those). The Python wrappers branch on the preview shape and no longer assume `result_ids` on success.

**Scope.** Booleans only, per your call. The same compute-then-commit structure exists in `split_curve`, `loft`, `sweep1`, `offset_curve` and `pipe` if the contract proves useful; `extrude_curve` and `intersect_curves` interleave compute with document writes, so they are not claimed here.

**Tests.** Schema: positive cases for the committed, solid-preview and invalid-preview (no area/volume) shapes plus negatives (missing result_ids, missing would_succeed, missing is_solid, wrong types, unknown fields). Server: wrapper unit tests, mock parity (prediction shape, no object consumption, declarative rejection mirror, delta/health gating), integration tests for predict-then-commit, inputs surviving a preview, dry_run with perception on carrying no `_delta`/`_health`, dry_run rejected on an unsupported command, and strict-mode validation of both response shapes. Plugin: mcptest cases for prediction-and-doc-unchanged and difference/intersection shapes. Live on a deployed build in Rhino 8: predicted union volume 14.0 vs committed 14.0 exact, error text byte-identical between preview and real on a rejected input, disjoint preview says nothing would merge, "Command create_object does not support dry_run" comes back fail-closed with nothing created, and both live response shapes validate against the new schema in strict mode. Full TestAllFunctions on the deployed build: all cases pass as on stock 0.3.2 (the pre-existing modify_object_no_shear failure noted in #45 aside). dotnet Release build clean, server pytest 202 passing, `contracts/test_schemas.py` all passing.